### PR TITLE
Fixes a scaladoc typo UKNOWN -> UNKNOWN

### DIFF
--- a/generator/src/main/twirl/org/coursera/courier/templates/EnumClass.scala.txt
+++ b/generator/src/main/twirl/org/coursera/courier/templates/EnumClass.scala.txt
@@ -30,7 +30,7 @@
 
   /**
    * Converts a string to an enumeration value. If the string does not match
-   * any of the enumeration values, returns the $UKNOWN enumeration value.
+   * any of the enumeration values, returns the \$UNKNOWN enumeration value.
    */
   def fromString(s: String): Value = {
     values.find(_.toString == s).getOrElse($UNKNOWN)


### PR DESCRIPTION
Also escapes the `$` so scaladoc does not complain about undefined macros (Scaladoc uses that symbol to encode re-usable macros).

I compile my current project with strict warnings, so this was (funny enough) causing my play app's `stage` command to fail on the generated types.
