### PR TITLE
Importing a record without a namespace produces scala compile errors

### DIFF
--- a/reference-suite/src/main/courier/org/coursera/records/WithNoNamespaceField.courier
+++ b/reference-suite/src/main/courier/org/coursera/records/WithNoNamespaceField.courier
@@ -1,0 +1,5 @@
+namespace org.coursera.records
+
+record WithNoNamespaceField {
+  blah: WithoutNamespace
+}


### PR DESCRIPTION
# WORK IN PROGRESS DO NOT MERGE

This is an initial commit that demonstrates a bug. I'll push the fix shortly.

If any record imports a non-namespaced record, the generated scala is broken. It probably requires a `_root_.` import.

I came across this error while trying to make a courier format for storage in ElasticSearch. ElasticSearch as of v2.0 does not support dot-notation in field names, which makes it impossible to store namespaced unions unless they are `flatTyped`, which isn't supported across all generators (most notably typescript-lite).

My fairly gross workaround was to put the unioned records in the global namespace (which will stop them from having dots), but then I came across this issue!

An example of the output:

``` bash
[error] /Users/eboto/code/courier/scala/generator-test/target/scala-2.10/courier/org/coursera/records/WithNoNamespaceField.scala:54: not found: type WithoutNamespace
[error]   lazy val blah: WithoutNamespace = obtainWrapped(WithNoNamespaceField.Fields.blah, classOf[WithoutNamespace])

```
