### PR TITLE
Add missing imports to Scala union template

### DIFF
--- a/scala/generator/src/main/twirl/org/coursera/courier/templates/UnionClass.scala.txt
+++ b/scala/generator/src/main/twirl/org/coursera/courier/templates/UnionClass.scala.txt
@@ -14,10 +14,12 @@
   import com.linkedin.data.ByteString
   import com.linkedin.data.schema.UnionDataSchema
   import com.linkedin.data.schema.TyperefDataSchema
+  import com.linkedin.data.template.Custom
   import com.linkedin.data.template.DataTemplateUtil
   import com.linkedin.data.template.UnionTemplate
   import org.coursera.courier.templates.DataTemplates.DataConversion
   import org.coursera.courier.templates.ScalaUnionTemplate
+  import org.coursera.courier.coercers.SingleElementCaseClassCoercer
   import org.coursera.courier.companions.UnionCompanion
   import org.coursera.courier.companions.UnionMemberCompanion
   import org.coursera.courier.companions.UnionWithTyperefCompanion


### PR DESCRIPTION
This fixes #32 wherein a top level typedef to a union containing a custom type would not compile due to missing imports.
