### PR TITLE
Record equality should take the type of the record into account

### DIFF
--- a/reference-suite/src/main/courier/org/coursera/records/test/Empty2.courier
+++ b/reference-suite/src/main/courier/org/coursera/records/test/Empty2.courier
@@ -1,3 +1,3 @@
 namespace org.coursera.records.test
 
-record Empty {}
+record Empty2 {}

--- a/reference-suite/src/main/courier/org/coursera/records/test/packaging/Empty.courier
+++ b/reference-suite/src/main/courier/org/coursera/records/test/packaging/Empty.courier
@@ -1,0 +1,3 @@
+namespace org.coursera.records.test.packaging
+
+record Empty {}

--- a/scala/generator-test/src/test/scala/org/coursera/courier/generator/RecordGeneratorTest.scala
+++ b/scala/generator-test/src/test/scala/org/coursera/courier/generator/RecordGeneratorTest.scala
@@ -22,6 +22,8 @@ import org.coursera.courier.templates.DataTemplates
 import DataTemplates.DataConversion
 import org.coursera.courier.generator.customtypes.CustomInt
 import org.coursera.enums.Fruits
+import org.coursera.records.test.Empty
+import org.coursera.records.test.Empty2
 import org.coursera.records.test.InlineOptionalRecord
 import org.coursera.records.test.InlineRecord
 import org.coursera.records.test.Simple
@@ -31,7 +33,6 @@ import org.coursera.records.test.WithComplexTypes
 import org.coursera.records.test.WithInclude
 import org.coursera.records.test.WithInlineRecord
 import org.coursera.records.test.WithOptionalComplexTypeDefaults
-import org.coursera.records.test.WithOptionalComplexTypes
 import org.coursera.records.test.WithOptionalComplexTypesDefaultNone
 import org.coursera.records.test.WithOptionalPrimitiveCustomTypes
 import org.coursera.records.test.WithOptionalPrimitiveDefaultNone
@@ -444,5 +445,29 @@ class RecordGeneratorTest extends GeneratorTest with SchemaFixtures {
     mutableData.getDataMap("record").put("message", "updated message")
     val replacement = original.copy(mutableData, DataConversion.SetReadOnly)
     assert(replacement.record.get.message.get === "updated message")
+  }
+
+  @Test
+  def testEquality(): Unit = {
+    // Equality should work for identical records of the same type
+    val record = Empty()
+    val recordSame = Empty()
+    assert(record == recordSame)
+    assert(record.hashCode() == recordSame.hashCode())
+
+    // Records with the same fields but different types should not be equal
+    val recordSameFields = Empty2()
+    assert(record != recordSameFields)
+    assert(record.hashCode() != recordSameFields.hashCode())
+
+    // Records with the same fields but different types (even if the pathless record type names
+    // are the same) should not be equal.
+    import org.coursera.records.test.packaging.{Empty => EmptySameName}
+    val recordSameName = EmptySameName()
+    assert(record != recordSameName)
+    // Note that because hashCode only uses productPrefix, which is the name of the record
+    // without its path, record.hashCode() will actually equal recordSameName.hashCode().
+    // Fortunately, nothing should depend solely on hashCode() for determining whether two
+    // records match.
   }
 }

--- a/scala/generator/src/main/twirl/org/coursera/courier/templates/RecordClass.scala.txt
+++ b/scala/generator/src/main/twirl/org/coursera/courier/templates/RecordClass.scala.txt
@@ -141,7 +141,7 @@
 
   override def hashCode: Int = ScalaRunTime._hashCode(this)
 
-  override def equals(that: Any): Boolean = ScalaRunTime._equals(this, that)
+  override def equals(that: Any): Boolean = canEqual(that) && ScalaRunTime._equals(this, that)
 
   override def toString: String = ScalaRunTime._toString(this)
 


### PR DESCRIPTION
Currently, record equality delegates to ScalaRunTime._equals, which takes only the elements of the record into account and not its productPrefix or type. We additionally check canEqual, which uses isInstanceOf, to ensure that the types can be equal.
