### PR TITLE
Typescript: add basic enum reflection

### DIFF
--- a/typescript-lite/README.md
+++ b/typescript-lite/README.md
@@ -89,6 +89,8 @@ export module MagicEightBallAnswer {
   export const ASK_AGAIN_LATER: MagicEightBallAnswer = "ASK_AGAIN_LATER";
 
   export const OUTLOOK_NOT_SO_GOOD: MagicEightBallAnswer = "OUTLOOK_NOT_SO_GOOD";
+
+  export const all: Array<MagicEightBallAnswer> = ["IT_IS_CERTAIN", "ASK_AGAIN_LATER", "OUTLOOK_NOT_SO_GOOD"];
 }
 ```
 
@@ -109,6 +111,8 @@ switch(answer) {
     // value from a new version of the server software. This is the equivalent of
     // testing UNKNOWN$
 }
+
+console.log(MagicEightBallAnswer.all); // logs all possible enum values to console
 ```
 **Arrays:**
 

--- a/typescript-lite/generator/src/main/java/org/coursera/courier/tslite/TSSyntax.java
+++ b/typescript-lite/generator/src/main/java/org/coursera/courier/tslite/TSSyntax.java
@@ -139,7 +139,7 @@ public class TSSyntax {
 
   /** Different choices for how to escaping symbols that match reserved ts keywords. */
   private static enum EscapeStrategy {
-    /** Adds an underscore after the symbol name when escaping. e.g.: class becomes class$*/
+    /** Adds a dollar sign after the symbol name when escaping. e.g.: class becomes class$ */
     MANGLE,
 
     /** Quotes the symbol when escaping. e.g.: class becomes "class" */

--- a/typescript-lite/generator/src/main/java/org/coursera/courier/tslite/TSSyntax.java
+++ b/typescript-lite/generator/src/main/java/org/coursera/courier/tslite/TSSyntax.java
@@ -139,7 +139,7 @@ public class TSSyntax {
 
   /** Different choices for how to escaping symbols that match reserved ts keywords. */
   private static enum EscapeStrategy {
-    /** Adds an underscore after the symbol name when escaping. e.g.: class becomes class_*/
+    /** Adds an underscore after the symbol name when escaping. e.g.: class becomes class$*/
     MANGLE,
 
     /** Quotes the symbol when escaping. e.g.: class becomes "class" */
@@ -989,28 +989,29 @@ public class TSSyntax {
     }
 
     /**
-     * Creates the string literal union for this enum. E.g. for Fruits { APPLE, ORANGE } it will produce
+     * Creates the string literal union for this enum.
      *
-     * export type Fruit = "APPLE" | "ORANGE";
+     * e.g. for Fruits { APPLE, ORANGE } it will produce the following valid typescript:
+     *
+     * "APPLE" | "ORANGE"
      **/
     public String stringLiteralUnion() {
       List<TSEnumSymbolSyntax> symbols = this.symbols();
-      if (this.symbols().size() == 0) {
+      if (symbols.size() == 0) {
         return "void"; // Helps us compile if some bozo declared an empty union.
       } else {
-        StringBuilder sb = new StringBuilder();
-
-        for (int i = 0; i < symbols.size(); i++) {
-          TSEnumSymbolSyntax symbol = symbols.get(i);
-          boolean isLast = (i + 1 == symbols.size());
-          sb.append(symbol.stringLiteralValue());
-
-          if (!isLast) {
-            sb.append(" | ");
-          }
-        }
-        return sb.toString();
+        return this._interleaveSymbolStrings(" | ");
       }
+    }
+
+    /**
+     * Creates the typescript array literal for all values of this enum.
+     * e.g. for Fruits { APPLE, ORANGE } it will produce the following valid typescript:
+     *
+     * ["APPLE", "ORANGE"]
+     */
+    public String arrayLiteral() {
+      return "[" + this._interleaveSymbolStrings(", ") + "]";
     }
 
     @Override
@@ -1026,6 +1027,22 @@ public class TSSyntax {
         symbols.add(new TSEnumSymbolSyntax(_template, _dataSchema, symbol));
       }
       return symbols;
+    }
+
+    private String _interleaveSymbolStrings(String delimiter) {
+      List<TSEnumSymbolSyntax> symbols = this.symbols();
+
+      StringBuilder sb = new StringBuilder();
+      for (int i = 0; i < symbols.size(); i++) {
+        TSEnumSymbolSyntax symbol = symbols.get(i);
+        boolean isLast = (i + 1 == symbols.size());
+        sb.append(symbol.stringLiteralValue());
+
+        if (!isLast) {
+          sb.append(delimiter);
+        }
+      }
+      return sb.toString();
     }
   }
 }

--- a/typescript-lite/generator/src/main/resources/rythm-ts/enum.txt
+++ b/typescript-lite/generator/src/main/resources/rythm-ts/enum.txt
@@ -9,5 +9,7 @@ export type @enumeration.typeName() = @enumeration.stringLiteralUnion();
       @symbol.docString()
       export const @symbol.moduleConstValue(): @enumeration.typeName() = @symbol.stringLiteralValue();
     }
+
+    export const all: Array<@enumeration.typeName()> = @enumeration.arrayLiteral();
   }
 }

--- a/typescript-lite/testsuite/src/expected-successes/spec/bindings.spec.ts
+++ b/typescript-lite/testsuite/src/expected-successes/spec/bindings.spec.ts
@@ -293,6 +293,10 @@ describe("Enums", () => {
 
     expect(result).toEqual("It's still an apple");
   });
+
+  it("Should be enumerated with the .all function", () => {
+    expect(Fruits.all).toEqual(["APPLE", "BANANA", "ORANGE", "PINEAPPLE"]);
+  });
 });
 
 


### PR DESCRIPTION
This change will add a `.all` property to all enum companion modules, making it possible to map over all possible values.