### PR TITLE
Typescript: Fix bug that fails to transcribe symbol-level enum docs.

### DIFF
--- a/typescript-lite/generator/src/main/java/org/coursera/courier/tslite/TSSyntax.java
+++ b/typescript-lite/generator/src/main/java/org/coursera/courier/tslite/TSSyntax.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.Map;
 
 /**
  * Main work-horse for populating the ts-lite Rythm templates.
@@ -945,8 +946,7 @@ public class TSSyntax {
     }
 
     public String docString() {
-      DataMap docsBySymbol = (DataMap) _dataSchema.getProperties().getOrDefault("symbolDocs", new DataMap());
-      String symbolDoc = docsBySymbol.getString(_symbolString);
+      String symbolDoc = _dataSchema.getSymbolDocs().get(_symbolString);
       DataMap deprecatedSymbols = (DataMap) _dataSchema.getProperties().get("deprecatedSymbols");
       Object symbolDeprecation = null;
 

--- a/typescript-lite/testsuite/src/expected-successes/spec/bindings.spec.ts
+++ b/typescript-lite/testsuite/src/expected-successes/spec/bindings.spec.ts
@@ -139,6 +139,7 @@ import { DateTime as OtherDateTime } from "../tslite-bindings/org.example.other.
 import { record } from "../tslite-bindings/org.example.record";
 import { WithPrimitivesUnion } from "../tslite-bindings/org.coursera.unions.WithPrimitivesUnion";
 import * as ts from "typescript";
+const fs = require('fs');
 
 import CustomMatcherFactories = jasmine.CustomMatcherFactories;
 import CompilerOptions = ts.CompilerOptions;
@@ -292,6 +293,15 @@ describe("Enums", () => {
     }
 
     expect(result).toEqual("It's still an apple");
+  });
+
+  it("Should transcribe both the class-level and symbol-level documentation from the courier spec", () => {
+    const fruitsFile = fs.readFileSync("src/tslite-bindings/org.coursera.enums.Fruits.ts").toString();
+    const typeComment = "An enum dedicated to the finest of the food groups.";
+    const symbolComment = "An Apple.";
+
+    expect(fruitsFile).toContain(typeComment);
+    expect(fruitsFile).toContain(symbolComment);
   });
 });
 

--- a/typescript-lite/testsuite/src/expected-successes/spec/bindings.spec.ts
+++ b/typescript-lite/testsuite/src/expected-successes/spec/bindings.spec.ts
@@ -302,7 +302,7 @@ describe("Enums", () => {
 
     expect(fruitsFile).toContain(typeComment);
     expect(fruitsFile).toContain(symbolComment);
-  }
+  });
 
   it("Should be enumerated with the .all function", () => {
     expect(Fruits.all).toEqual(["APPLE", "BANANA", "ORANGE", "PINEAPPLE"]);

--- a/typescript-lite/testsuite/src/expected-successes/spec/bindings.spec.ts
+++ b/typescript-lite/testsuite/src/expected-successes/spec/bindings.spec.ts
@@ -302,6 +302,7 @@ describe("Enums", () => {
 
     expect(fruitsFile).toContain(typeComment);
     expect(fruitsFile).toContain(symbolComment);
+  }
 
   it("Should be enumerated with the .all function", () => {
     expect(Fruits.all).toEqual(["APPLE", "BANANA", "ORANGE", "PINEAPPLE"]);


### PR DESCRIPTION
I believe [this commit](https://github.com/coursera/courier/commit/36ba54afd88f63a19aec677f91817745570373dc) regressed typescript enum generation. It caused symbol docs to not be transcribed.

I'll fix the issue and add a test-case here.