### PR TITLE
WIP Py3 bindings

### DIFF
--- a/generator-api/src/main/java/org/coursera/courier/api/DefaultGeneratorRunner.java
+++ b/generator-api/src/main/java/org/coursera/courier/api/DefaultGeneratorRunner.java
@@ -131,7 +131,8 @@ public class DefaultGeneratorRunner implements GeneratorRunner {
         (Collection<File>)FileUtils.listFiles(targetDirectory, null, true);
 
     for (File existingFile : existingFiles) {
-      if (!targetFiles.contains(existingFile)) {
+      // TODO(py3): Get rid of this terrible __init__.py hack before un-WIPping this PR
+      if (!targetFiles.contains(existingFile) && !existingFile.getAbsoluteFile().getName().contains("__init__.py")) {
         FileUtils.forceDelete(existingFile);
       }
     }
@@ -174,6 +175,15 @@ public class DefaultGeneratorRunner implements GeneratorRunner {
       throw new IllegalArgumentException(
           "unable to create directory, or directory path exists but is not a directory: " +
               directory.getAbsolutePath());
+    }
+
+    // TODO(py3): Get rid of this before PRing for god sake. Find a better way to do this in courier
+    File py3Init = new File(directory, "__init__.py");
+    System.err.println(py3Init.getAbsolutePath());
+    if (!py3Init.exists()) {
+      if (!py3Init.createNewFile()) {
+        throw new IllegalArgumentException("Unable to create file " + py3Init.getAbsolutePath());
+      }
     }
 
     if (!file.exists()) {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -155,19 +155,25 @@ object Courier extends Build with OverridablePublishSettings {
   lazy val typescriptLiteGenerator = Project(id = "typescript-lite-generator", base = typescriptLiteDir / "generator")
     .dependsOn(generatorApi)
 
+  private[this] val python3Dir = file("python3")
+  lazy val python3Generator = Project(id = "python3-generator", base = python3Dir / "generator")
+    .dependsOn(generatorApi)
+
   lazy val cli = Project(id = "courier-cli", base = file("cli"))
     .dependsOn(
       javaGenerator,
       androidGenerator,
       scalaGenerator,
       typescriptLiteGenerator,
-      swiftGenerator
+      swiftGenerator,
+      python3Generator
     ).aggregate(
       javaGenerator,
       androidGenerator,
       scalaGenerator,
       typescriptLiteGenerator,
-      swiftGenerator
+      swiftGenerator,
+      python3Generator
     ).settings(
       executableFile := {
         val exeFile = target.value / "courier"
@@ -186,6 +192,11 @@ object Courier extends Build with OverridablePublishSettings {
   lazy val typescriptLiteGeneratorTest = Project(
     id = "typescript-lite-generator-test", base = typescriptLiteDir / "generator-test")
     .dependsOn(typescriptLiteGenerator)
+
+  lazy val python3GeneratorTest = Project(
+    id = "python3-generator-test", base = python3Dir / "generator-test")
+    .dependsOn(python3Generator)
+
 
   lazy val courierSbtPlugin = Project(id = "sbt-plugin", base = file("sbt-plugin"))
     .dependsOn(scalaGenerator)
@@ -218,6 +229,7 @@ object Courier extends Build with OverridablePublishSettings {
     s";project android-runtime;$publishCommand" +
     s";project swift-generator;$publishCommand" +
     s";project typescript-lite-generator;$publishCommand" +
+    s";project python3-generator;$publishCommand" +
     s";++$sbtScalaVersion;project scala-generator;$publishCommand" +
     s";++$currentScalaVersion;project scala-generator;$publishCommand" +
     s";++$sbtScalaVersion;project sbt-plugin;$publishCommand" +

--- a/python3/.gitignore
+++ b/python3/.gitignore
@@ -1,0 +1,11 @@
+.gradle
+build/
+
+generator/build
+testsuite/testsuiteTests/generated
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar

--- a/python3/README.md
+++ b/python3/README.md
@@ -1,0 +1,316 @@
+Typescript-Lite Courier Data Binding Generator
+==============================================
+
+Experimental!
+
+Lightweight Courier bindings for Typescript.
+
+The guiding philosophy here was to achieve type safety with as small a runtime footprint as possible -- use the fact
+that JSON is native to javascript to lightly define types and interfaces that describe your courier specs.
+
+These bindings will achieve their goal if:
+
+ * You can just cast the result of a JSON HTTP response (or other JSON source) into the base expected
+   type and stay typesafe without having to cast anything more afterwards.
+ * You can hand-write JSON in your test-cases and API requests, and those test-cases
+   fail to compile when the record contract breaks.
+ * You can enjoy the sweet auto-complete and compile-time warnings you've come to enjoy from typescript.
+
+These bindings require Typescript 1.8+
+
+Features missing in action
+--------------------------
+
+* **Coercer support**. The strong runtime component of Coercers don't gel easily with the philosophy of casting records
+  lightly into target typescript interfaces, so there wasn't an easy fit.
+    * Maybe these get included when Typescript-lite becomes just plain ol typescript.
+* **Keyed maps**. Javascript objects naturally only support string-keyed maps. Since we are avoiding runtime
+  overhead as much as possible we did not want to introduce a new type, nor the means to serialize said type.
+    * Integrating `Immutable.js` would make a lot of sense when we want to expand into this direction.
+    * These bindings will coerce keyed maps into string-keyed maps (which they are on the wire anyways)
+* **Non-JSON serialization**. Although courier supports more compact binary formats (PSON, Avro, BSON), Typescript-lite
+  bindings currently only supports valid JSON objects.
+* **Default values**. As with the other points, default values require a runtime.
+* **Flat-typed definitions**. This was just an oversight. Gotta add these.
+
+Running the generator from the command line
+-------------------------------------------
+
+Build a fat jar from source and use that. See the below section *Building a fat jar*.
+
+How code is generated
+---------------------
+
+**Records:**
+
+* Records are generated as an interface within the typescript `namespace` specified by your record.
+  * If you don't use a namespace, the interface will be injected at the top-level
+
+e.g. the result of [Fortune.courier](https://github.com/coursera/courier/blob/master/reference-suite/src/main/courier/org/example/Fortune.courier):
+
+```typescript
+// ./my-py3-bindings/org.example.Fortune.ts
+import { FortuneTelling } from "./org.example.FortuneTelling";
+import { DateTime } from "./org.example.common.DateTime";
+
+/**
+ * A fortune.
+ */
+export interface Fortune {
+
+  /**
+   * The fortune telling.
+   */
+  telling : FortuneTelling;
+
+  createdAt : DateTime;
+}
+```
+
+**Enums:**
+
+* Enums are represented as [string literal types](https://basarat.gitbooks.io/typescript/content/docs/types/stringLiteralType.html).
+* Convenience constants matching the string literals are provided despite having a runtime cost
+* Unlike other bindings, Typescript-lite does not include an `UNKNOWN$` option. In case of wire inconsistency
+  you will have to just fall through to `undefined`.
+
+e.g. the result of [MagicEightBallAnswer.courier](https://github.com/coursera/courier/blob/master/reference-suite/src/main/courier/org/example/MagicEightBallAnswer.courier):
+
+```typescript
+// ./my-py3-bindings/org.example.MagicEightBallAnswer.ts
+/**
+ * Magic eight ball answers.
+ */
+export type MagicEightBallAnswer =  "IT_IS_CERTAIN"  | "ASK_AGAIN_LATER"  | "OUTLOOK_NOT_SO_GOOD" ;
+export module MagicEightBallAnswer {
+
+  export const IT_IS_CERTAIN: MagicEightBallAnswer = "IT_IS_CERTAIN";
+
+  export const ASK_AGAIN_LATER: MagicEightBallAnswer = "ASK_AGAIN_LATER";
+
+  export const OUTLOOK_NOT_SO_GOOD: MagicEightBallAnswer = "OUTLOOK_NOT_SO_GOOD";
+
+  export const all: Array<MagicEightBallAnswer> = ["IT_IS_CERTAIN", "ASK_AGAIN_LATER", "OUTLOOK_NOT_SO_GOOD"];
+}
+```
+
+```typescript
+// Some other file
+// You can use it like this
+
+const answer: MagicEightBallAnswer = "IT_IS_CERTAIN";
+switch(answer) {
+  case MagicEightBallAnswer.IT_IS_CERTAIN:
+    // do something
+    break;
+  case MagicEightBallAnswer.ASK_AGAIN_LATER:
+    // do something
+    break;
+  default:
+    // you should probably always check this...in case you got some new unexpected
+    // value from a new version of the server software. This is the equivalent of
+    // testing UNKNOWN$
+}
+
+console.log(MagicEightBallAnswer.all); // logs all possible enum values to console
+```
+**Arrays:**
+
+* Arrays are represented as typescript arrays.
+
+**Maps:**
+
+* Maps are represented as javascript objects, as interfaced by `courier.Map<ValueT>`
+* Only string-keyed maps are currently supported.
+
+**Unions:**
+
+* Unions are represented as an intersection type between all the members of the union.
+* A Run-time `unpack` accessor is provided to test each aspect of the union
+* Unlike other serializers, no `UNKNOWN$` member is generated for the union. If all provided accessors end up yielding
+  undefined, then conclude that it was an unknown union member (see second example)
+
+e.g. The result of [FortuneTelling.pdsc](https://github.com/coursera/courier/blob/master/reference-suite/src/main/pegasus/org/example/FortuneTelling.pdsc):
+```typescript
+// file: my-py3-bindings/org.example.FortuneTelling.ts
+import { MagicEightBall } from "./org.example.MagicEightBall";
+import { FortuneCookie } from "./org.example.FortuneCookie";
+
+export type FortuneTelling =  FortuneTelling.FortuneCookieMember | FortuneTelling.MagicEightBallMember | FortuneTelling.StringMember;
+export module FortuneTelling {
+  export interface FortuneTellingMember {
+    [key: string]:  FortuneCookie | MagicEightBall | string;
+  }
+
+  export interface FortuneCookieMember extends FortuneTellingMember {
+    "org.example.FortuneCookie": FortuneCookie;
+  }
+
+  export interface MagicEightBallMember extends FortuneTellingMember {
+    "org.example.MagicEightBall": MagicEightBall;
+  }
+
+  export interface StringMember extends FortuneTellingMember {
+    "string": string;
+  }
+
+  export function unpack(union: FortuneTelling) {
+    return {
+      fortuneCookie: union["org.example.FortuneCookie"] as FortuneCookie,
+      magicEightBall: union["org.example.MagicEightBall"] as MagicEightBall,
+      string$: union["string"] as string
+    };
+  }
+}
+```
+
+Here's how you would use one:
+```typescript
+import { FortuneTelling } from "./my-py3-bindings/org.example.FortuneTelling";
+import { MacigEightBall } from "./my-py3-bindings/org.example.MagicEightBall";
+import { FortuneCookie } from "./my-py3-bindings/org.example.FortuneCookie";
+
+const telling: FortuneTelling = /* Get the union from somewhere...probably the wire */;
+
+const { fortuneCookie, magicEightBall, string_ } = FortuneTelling.unpack(telling);
+
+if (fortuneCookie) {
+  // do something with fortuneCookie
+} else if (magicEightBall) {
+  // do something with magicEightBall
+} else if (string$) {
+  // do something with str
+} else {
+  throw 'a fit because no one will tell your fortune';
+}
+```
+
+Projections and Optionality
+---------------------------
+
+These bindings do not currently support projections. If you need to use projections, then
+generate your bindings with Optionality of REQUIRED_FIELDS_MAY_BE_ABSENT rather than STRICT
+as the 4th argument to the generator tool.
+
+That said, here is a good way we could evolve to support projections:
+
+I think [Intersection types](https://basarat.gitbooks.io/typescript/content/docs/types/type-system.html#intersection-type) may be a good approach in typescript
+
+Imagine the following courier type:
+
+```
+record Message {
+  id: string;
+  subject: string;
+  body: string;
+}
+```
+
+If we wanted to support projections, we could generate the following types
+
+```typescript
+module Message {
+  interface Id {
+    id: string;
+  }
+  interface Subject {
+    subject: string;
+  }
+
+  interface Body {
+     body: string;
+  }
+}
+type Message = Message.Id & Message.Subject & Message.Body;
+```
+
+In your application code when you request some projection, instead of using the Message type you could just safely cast the message down to its component projections! For example:
+
+```typescript
+function getMessageIdAndBody(id: string): Promise<Message.Id & Message.Body> {
+  return http.get('/messages/' + id + '?projection=(id,body)').then((resp) => {
+    return resp.data as (Message.Id & Message.Body);
+  })
+}
+```
+
+Any attempt to access `message.subject` from the results of that function would of course fail at compile time.
+
+
+Custom Types
+------------
+
+Custom Types allow any Typescript type to be bound to any pegasus primitive type.
+
+For example, say a schema has been defined to represent a "date time" as a unix timestamp long:
+
+```
+namespace org.example
+
+typeref DateTime = long
+```
+
+This results in a typescript file:
+```typescript
+// ./my-py3-bindings/org.coursera.customtypes.DateTime.ts
+export type DateTime = number;
+```
+
+JSON Serialization / Deserialization
+------------------------------------
+
+JSON serialization is trivial in typescript. Just take use `JSON.stringify` on any courier type that compiles.
+
+```typescript
+import { Message } from "./my-py3-bindings/org.coursera.records.Message";
+
+const message: Message = {"body": "Hello Pegasus!"};
+const messageJson = JSON.stringify(message);
+```
+
+And of course you can read results as well.
+
+```typescript
+import { Message } from "./my-py3-bindings/org.coursera.records.Message";
+
+const messageStr: string = /* Get the message string somehow */
+const message = JSON.parse(messageStr) as Message;
+```
+
+Runtime library
+---------------
+
+All generated Typescript-lite bindings depend on a `CourierRuntime.ts` class. This class provides the very minimal
+functionality and type definitions necessary for generated bindings to work.
+
+Building from source
+--------------------
+
+See the main CONTRIBUTING document for details.
+
+Building a Fat Jar
+------------------
+
+```sh
+$ sbt
+> project typescript-lite-generator
+> assembly
+```
+
+This will build a standalone "fat jar". This is particularly convenient for use as a standalone
+commandline application.
+
+Testing
+-------
+
+1. No testing has been done yet except verifying that the generated files from reference-suite pass `tsc`.
+   That's next on the list =)
+
+TODO
+----
+
+* [ ] Add support for flat type definitions
+* [ ] Figure out the best way to distribute the 'fat jar'.
+* [ ] Automate distribution of the Fat Jar
+* [ ] Publish Fat Jar to remote repos? Typically fat jars should not be published to maven/ivy
+      repos, but maybe it should be hosted for easy download elsewhere?

--- a/python3/README.md
+++ b/python3/README.md
@@ -22,6 +22,8 @@ this thing is ready for submit:
   - [ ] **$UNKNOWN** on enums.
   
 Additional tasks before merging to courier master:
+  - [ ] Fix the most heinous `TODO` items from the changelist.
+    - Specifically the ones that alter the general, not-only-py3 code.
   - [ ] Hook into the top-level cli
   - [ ] Many additional test-cases
   - [ ] Populate this documentation
@@ -29,11 +31,21 @@ Additional tasks before merging to courier master:
 Additional desirable tasks for later:
   - [ ] Ship `courier.py` as a package through `pip` instead of through the
         generator
-
+  - [ ] Examine abstractions that unify code the large amount of overlap between TSLite and Python3 code generation.
+        Hopefully this can lead to writing new bindings more easily down the road.
+  
 Running the generator from the command line
 -------------------------------------------
 
-Build a fat jar from source and use that. See the below section *Building a fat jar*.
+Build a fat jar from source and use that. 
+
+```bash
+$ sbt
+> project python3-generator
+> assembly
+# Wait for a bit...
+[info] Packaging /Users/eboto/code/courier/python3/generator/target/courier-python3-generator-2.0.8.jar ...
+```
 
 To see usage, execute `java -jar <the generated jar>`
 
@@ -41,29 +53,12 @@ Runtime library
 ---------------
 
 All generated Python3 bindings depend on a `courier.py` class. This class provides the consistent
-runtime aspect necessary for generated bindings to work.
-
-Building from source
---------------------
-
-See the main CONTRIBUTING document for details.
-
-Building a Fat Jar
-------------------
-
-```bash
-$ sbt
-> project python3-generator
-> assembly
-```
-
-This will build a standalone "fat jar". This is particularly convenient for use as a standalone
-commandline application.
+runtime aspect necessary for generated bindings to work. It is shipped with the bindings.
 
 Testing
 -------
 
-Exhaustive tests are run against the reference test-suite. To execute them:
+Not-that-exhaustive tests are run against the reference suite. To execute them:
 
 ```bash
 $ sbt

--- a/python3/README.md
+++ b/python3/README.md
@@ -1,287 +1,47 @@
-Typescript-Lite Courier Data Binding Generator
+Python3 Courier Data Binding Generator
 ==============================================
 
-Experimental!
-
-Lightweight Courier bindings for Typescript.
-
-The guiding philosophy here was to achieve type safety with as small a runtime footprint as possible -- use the fact
-that JSON is native to javascript to lightly define types and interfaces that describe your courier specs.
-
-These bindings will achieve their goal if:
-
- * You can just cast the result of a JSON HTTP response (or other JSON source) into the base expected
-   type and stay typesafe without having to cast anything more afterwards.
- * You can hand-write JSON in your test-cases and API requests, and those test-cases
-   fail to compile when the record contract breaks.
- * You can enjoy the sweet auto-complete and compile-time warnings you've come to enjoy from typescript.
-
-These bindings require Typescript 1.8+
+Courier bindings for Python 3 (tested against Python 3.6)
 
 Features missing in action
 --------------------------
 
-* **Coercer support**. The strong runtime component of Coercers don't gel easily with the philosophy of casting records
-  lightly into target typescript interfaces, so there wasn't an easy fit.
-    * Maybe these get included when Typescript-lite becomes just plain ol typescript.
-* **Keyed maps**. Javascript objects naturally only support string-keyed maps. Since we are avoiding runtime
-  overhead as much as possible we did not want to introduce a new type, nor the means to serialize said type.
-    * Integrating `Immutable.js` would make a lot of sense when we want to expand into this direction.
-    * These bindings will coerce keyed maps into string-keyed maps (which they are on the wire anyways)
-* **Non-JSON serialization**. Although courier supports more compact binary formats (PSON, Avro, BSON), Typescript-lite
-  bindings currently only supports valid JSON objects.
-* **Default values**. As with the other points, default values require a runtime.
-* **Flat-typed definitions**. This was just an oversight. Gotta add these.
+Mainline Courier features that are not yet supported, but will be by the time
+this thing is ready for submit:
+  - [ ] **Coercers**
+  - [ ] **Non-primitive keyed maps**. Hashcode not yet implemented for
+        non-primitives.
+  - [ ] **Non-JSON serialization**. Though avro should be trivial with existing
+        avro libraries.
+  - [ ] **Default values**.
+  - [ ] **Flat-typed definitions**.
+  - [ ] **Optional fields**. Currently all fields in `MyRecord.create` are
+        required. These should be easy to add.
+  - [ ] **Deprecation**.
+  - [ ] **Enum properties**. No `Fruits.BANANA.property("color")`
+  - [ ] **$UNKNOWN** on enums.
+  
+Additional tasks before merging to courier master:
+  - [ ] Hook into the top-level cli
+  - [ ] Many additional test-cases
+  - [ ] Populate this documentation
+  
+Additional desirable tasks for later:
+  - [ ] Ship `courier.py` as a package through `pip` instead of through the
+        generator
 
 Running the generator from the command line
 -------------------------------------------
 
 Build a fat jar from source and use that. See the below section *Building a fat jar*.
 
-How code is generated
----------------------
-
-**Records:**
-
-* Records are generated as an interface within the typescript `namespace` specified by your record.
-  * If you don't use a namespace, the interface will be injected at the top-level
-
-e.g. the result of [Fortune.courier](https://github.com/coursera/courier/blob/master/reference-suite/src/main/courier/org/example/Fortune.courier):
-
-```typescript
-// ./my-py3-bindings/org.example.Fortune.ts
-import { FortuneTelling } from "./org.example.FortuneTelling";
-import { DateTime } from "./org.example.common.DateTime";
-
-/**
- * A fortune.
- */
-export interface Fortune {
-
-  /**
-   * The fortune telling.
-   */
-  telling : FortuneTelling;
-
-  createdAt : DateTime;
-}
-```
-
-**Enums:**
-
-* Enums are represented as [string literal types](https://basarat.gitbooks.io/typescript/content/docs/types/stringLiteralType.html).
-* Convenience constants matching the string literals are provided despite having a runtime cost
-* Unlike other bindings, Typescript-lite does not include an `UNKNOWN$` option. In case of wire inconsistency
-  you will have to just fall through to `undefined`.
-
-e.g. the result of [MagicEightBallAnswer.courier](https://github.com/coursera/courier/blob/master/reference-suite/src/main/courier/org/example/MagicEightBallAnswer.courier):
-
-```typescript
-// ./my-py3-bindings/org.example.MagicEightBallAnswer.ts
-/**
- * Magic eight ball answers.
- */
-export type MagicEightBallAnswer =  "IT_IS_CERTAIN"  | "ASK_AGAIN_LATER"  | "OUTLOOK_NOT_SO_GOOD" ;
-export module MagicEightBallAnswer {
-
-  export const IT_IS_CERTAIN: MagicEightBallAnswer = "IT_IS_CERTAIN";
-
-  export const ASK_AGAIN_LATER: MagicEightBallAnswer = "ASK_AGAIN_LATER";
-
-  export const OUTLOOK_NOT_SO_GOOD: MagicEightBallAnswer = "OUTLOOK_NOT_SO_GOOD";
-
-  export const all: Array<MagicEightBallAnswer> = ["IT_IS_CERTAIN", "ASK_AGAIN_LATER", "OUTLOOK_NOT_SO_GOOD"];
-}
-```
-
-```typescript
-// Some other file
-// You can use it like this
-
-const answer: MagicEightBallAnswer = "IT_IS_CERTAIN";
-switch(answer) {
-  case MagicEightBallAnswer.IT_IS_CERTAIN:
-    // do something
-    break;
-  case MagicEightBallAnswer.ASK_AGAIN_LATER:
-    // do something
-    break;
-  default:
-    // you should probably always check this...in case you got some new unexpected
-    // value from a new version of the server software. This is the equivalent of
-    // testing UNKNOWN$
-}
-
-console.log(MagicEightBallAnswer.all); // logs all possible enum values to console
-```
-**Arrays:**
-
-* Arrays are represented as typescript arrays.
-
-**Maps:**
-
-* Maps are represented as javascript objects, as interfaced by `courier.Map<ValueT>`
-* Only string-keyed maps are currently supported.
-
-**Unions:**
-
-* Unions are represented as an intersection type between all the members of the union.
-* A Run-time `unpack` accessor is provided to test each aspect of the union
-* Unlike other serializers, no `UNKNOWN$` member is generated for the union. If all provided accessors end up yielding
-  undefined, then conclude that it was an unknown union member (see second example)
-
-e.g. The result of [FortuneTelling.pdsc](https://github.com/coursera/courier/blob/master/reference-suite/src/main/pegasus/org/example/FortuneTelling.pdsc):
-```typescript
-// file: my-py3-bindings/org.example.FortuneTelling.ts
-import { MagicEightBall } from "./org.example.MagicEightBall";
-import { FortuneCookie } from "./org.example.FortuneCookie";
-
-export type FortuneTelling =  FortuneTelling.FortuneCookieMember | FortuneTelling.MagicEightBallMember | FortuneTelling.StringMember;
-export module FortuneTelling {
-  export interface FortuneTellingMember {
-    [key: string]:  FortuneCookie | MagicEightBall | string;
-  }
-
-  export interface FortuneCookieMember extends FortuneTellingMember {
-    "org.example.FortuneCookie": FortuneCookie;
-  }
-
-  export interface MagicEightBallMember extends FortuneTellingMember {
-    "org.example.MagicEightBall": MagicEightBall;
-  }
-
-  export interface StringMember extends FortuneTellingMember {
-    "string": string;
-  }
-
-  export function unpack(union: FortuneTelling) {
-    return {
-      fortuneCookie: union["org.example.FortuneCookie"] as FortuneCookie,
-      magicEightBall: union["org.example.MagicEightBall"] as MagicEightBall,
-      string$: union["string"] as string
-    };
-  }
-}
-```
-
-Here's how you would use one:
-```typescript
-import { FortuneTelling } from "./my-py3-bindings/org.example.FortuneTelling";
-import { MacigEightBall } from "./my-py3-bindings/org.example.MagicEightBall";
-import { FortuneCookie } from "./my-py3-bindings/org.example.FortuneCookie";
-
-const telling: FortuneTelling = /* Get the union from somewhere...probably the wire */;
-
-const { fortuneCookie, magicEightBall, string_ } = FortuneTelling.unpack(telling);
-
-if (fortuneCookie) {
-  // do something with fortuneCookie
-} else if (magicEightBall) {
-  // do something with magicEightBall
-} else if (string$) {
-  // do something with str
-} else {
-  throw 'a fit because no one will tell your fortune';
-}
-```
-
-Projections and Optionality
----------------------------
-
-These bindings do not currently support projections. If you need to use projections, then
-generate your bindings with Optionality of REQUIRED_FIELDS_MAY_BE_ABSENT rather than STRICT
-as the 4th argument to the generator tool.
-
-That said, here is a good way we could evolve to support projections:
-
-I think [Intersection types](https://basarat.gitbooks.io/typescript/content/docs/types/type-system.html#intersection-type) may be a good approach in typescript
-
-Imagine the following courier type:
-
-```
-record Message {
-  id: string;
-  subject: string;
-  body: string;
-}
-```
-
-If we wanted to support projections, we could generate the following types
-
-```typescript
-module Message {
-  interface Id {
-    id: string;
-  }
-  interface Subject {
-    subject: string;
-  }
-
-  interface Body {
-     body: string;
-  }
-}
-type Message = Message.Id & Message.Subject & Message.Body;
-```
-
-In your application code when you request some projection, instead of using the Message type you could just safely cast the message down to its component projections! For example:
-
-```typescript
-function getMessageIdAndBody(id: string): Promise<Message.Id & Message.Body> {
-  return http.get('/messages/' + id + '?projection=(id,body)').then((resp) => {
-    return resp.data as (Message.Id & Message.Body);
-  })
-}
-```
-
-Any attempt to access `message.subject` from the results of that function would of course fail at compile time.
-
-
-Custom Types
-------------
-
-Custom Types allow any Typescript type to be bound to any pegasus primitive type.
-
-For example, say a schema has been defined to represent a "date time" as a unix timestamp long:
-
-```
-namespace org.example
-
-typeref DateTime = long
-```
-
-This results in a typescript file:
-```typescript
-// ./my-py3-bindings/org.coursera.customtypes.DateTime.ts
-export type DateTime = number;
-```
-
-JSON Serialization / Deserialization
-------------------------------------
-
-JSON serialization is trivial in typescript. Just take use `JSON.stringify` on any courier type that compiles.
-
-```typescript
-import { Message } from "./my-py3-bindings/org.coursera.records.Message";
-
-const message: Message = {"body": "Hello Pegasus!"};
-const messageJson = JSON.stringify(message);
-```
-
-And of course you can read results as well.
-
-```typescript
-import { Message } from "./my-py3-bindings/org.coursera.records.Message";
-
-const messageStr: string = /* Get the message string somehow */
-const message = JSON.parse(messageStr) as Message;
-```
+To see usage, execute `java -jar <the generated jar>`
 
 Runtime library
 ---------------
 
-All generated Typescript-lite bindings depend on a `CourierRuntime.ts` class. This class provides the very minimal
-functionality and type definitions necessary for generated bindings to work.
+All generated Python3 bindings depend on a `courier.py` class. This class provides the consistent
+runtime aspect necessary for generated bindings to work.
 
 Building from source
 --------------------
@@ -291,9 +51,9 @@ See the main CONTRIBUTING document for details.
 Building a Fat Jar
 ------------------
 
-```sh
+```bash
 $ sbt
-> project typescript-lite-generator
+> project python3-generator
 > assembly
 ```
 
@@ -303,14 +63,10 @@ commandline application.
 Testing
 -------
 
-1. No testing has been done yet except verifying that the generated files from reference-suite pass `tsc`.
-   That's next on the list =)
+Exhaustive tests are run against the reference test-suite. To execute them:
 
-TODO
-----
-
-* [ ] Add support for flat type definitions
-* [ ] Figure out the best way to distribute the 'fat jar'.
-* [ ] Automate distribution of the Fat Jar
-* [ ] Publish Fat Jar to remote repos? Typically fat jars should not be published to maven/ivy
-      repos, but maybe it should be hosted for easy download elsewhere?
+```bash
+$ sbt
+> project python3-generator-test
+> test
+```

--- a/python3/generator-test/build.sbt
+++ b/python3/generator-test/build.sbt
@@ -1,0 +1,45 @@
+import sbt.inc.Analysis
+
+name := "courier-python3-generator-test"
+
+packagedArtifacts := Map.empty // do not publish
+
+libraryDependencies ++= Seq(
+  ExternalDependencies.JodaTime.jodaTime)
+
+autoScalaLibrary := false
+
+crossPaths := false
+
+// Test Generator
+forkedVmCourierGeneratorSettings
+
+forkedVmCourierMainClass := "org.coursera.courier.Python3Generator"
+
+forkedVmCourierClasspath := (dependencyClasspath in Runtime in python3Generator).value.files
+
+forkedVmSourceDirectory := (sourceDirectory in referenceSuite).value / "main" / "courier"
+
+forkedVmCourierDest := file("python3") / "testsuite" / "src" / "py3bindings"
+
+forkedVmAdditionalArgs := Seq("STRICT")
+
+(compile in Compile) := {
+  (forkedVmCourierGenerator in Compile).value
+
+  Analysis.Empty
+}
+
+lazy val py3Test = taskKey[Unit]("Executes python unittest")
+
+py3Test in Test := {
+  (compile in Compile).value
+
+  val result = """./python3/testsuite/full-build.sh"""!
+
+  if (result != 0) {
+    throw new RuntimeException("Python3 Build Failed")
+  }
+}
+
+test in Test := (py3Test in Test).value

--- a/python3/generator-test/build.sbt
+++ b/python3/generator-test/build.sbt
@@ -30,14 +30,20 @@ forkedVmAdditionalArgs := Seq("STRICT")
   Analysis.Empty
 }
 
-lazy val py3Test = taskKey[Unit]("Executes python unittest")
+lazy val py3Test = taskKey[Boolean]("Executes python unittest")
 
 py3Test in Test := {
+  // Comment out the following line to just run the tests without
+  // new generation.
+  (compile in Compile).value
+
   val result = """./python3/testsuite/full-build.sh"""!
 
   if (result != 0) {
     throw new RuntimeException("Python3 Build Failed")
   }
+
+  true
 }
 
 test in Test := (py3Test in Test).value

--- a/python3/generator-test/build.sbt
+++ b/python3/generator-test/build.sbt
@@ -33,8 +33,6 @@ forkedVmAdditionalArgs := Seq("STRICT")
 lazy val py3Test = taskKey[Unit]("Executes python unittest")
 
 py3Test in Test := {
-  (compile in Compile).value
-
   val result = """./python3/testsuite/full-build.sh"""!
 
   if (result != 0) {

--- a/python3/generator/.gitignore
+++ b/python3/generator/.gitignore
@@ -1,0 +1,2 @@
+src/test/mainGeneratedPegasus
+src/main/mainGeneratedPegasus

--- a/python3/generator/build.sbt
+++ b/python3/generator/build.sbt
@@ -1,0 +1,19 @@
+import sbtassembly.AssemblyPlugin.defaultShellScript
+
+name := "courier-python3-generator"
+
+plainJavaProjectSettings
+
+libraryDependencies ++= Seq(
+  ExternalDependencies.Rythm.rythmEngine,
+  ExternalDependencies.Slf4j.slf4jSimple,
+  ExternalDependencies.Pegasus.dataAvro
+)
+
+// Fat Jar
+mainClass in assembly := Some("org.coursera.courier.Python3Generator")
+
+assemblyOption in assembly := (assemblyOption in assembly).value.copy(prependShellScript = Some(defaultShellScript))
+
+assemblyJarName in assembly := s"${name.value}-${version.value}.jar"
+

--- a/python3/generator/src/main/java/org/coursera/courier/Python3Generator.java
+++ b/python3/generator/src/main/java/org/coursera/courier/Python3Generator.java
@@ -25,8 +25,6 @@ import org.coursera.courier.api.GeneratedCode;
 import org.coursera.courier.api.GeneratedCodeTargetFile;
 import org.coursera.courier.api.GeneratorRunnerOptions;
 import org.coursera.courier.api.PegasusCodeGenerator;
-import org.coursera.courier.lang.DocCommentStyle;
-import org.coursera.courier.lang.PoorMansCStyleSourceFormatter;
 import org.coursera.courier.py3.GlobalConfig;
 import org.coursera.courier.py3.Py3Properties;
 import org.coursera.courier.py3.Py3Syntax;
@@ -37,6 +35,7 @@ import org.rythmengine.resource.ClasspathResourceLoader;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Collections;
@@ -88,8 +87,13 @@ public class Python3Generator implements PegasusCodeGenerator {
       System.out.println(file.getAbsolutePath());
     }
 
-    InputStream runtime = Python3Generator.class.getClassLoader().getResourceAsStream("runtime/courier.py");
-    IOUtils.copy(runtime, new FileOutputStream(new File(targetPath, "courier.py")));
+    _copyResourceToFile("runtime/courier.py", new File(targetPath, "courier.py"));
+    _copyResourceToFile("runtime/requirements.txt", new File(targetPath, "requirements.txt"));
+  }
+
+  private static void _copyResourceToFile(String resource, File targetFile) throws IOException {
+    InputStream runtime = Python3Generator.class.getClassLoader().getResourceAsStream(resource);
+    IOUtils.copy(runtime, new FileOutputStream(targetFile));
   }
 
   public Python3Generator() {

--- a/python3/generator/src/main/java/org/coursera/courier/Python3Generator.java
+++ b/python3/generator/src/main/java/org/coursera/courier/Python3Generator.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2016 Coursera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.coursera.courier;
+
+import com.linkedin.data.schema.DataSchema;
+import com.linkedin.pegasus.generator.GeneratorResult;
+import com.linkedin.pegasus.generator.spec.*;
+import org.apache.commons.io.IOUtils;
+import org.coursera.courier.api.DefaultGeneratorRunner;
+import org.coursera.courier.api.GeneratedCode;
+import org.coursera.courier.api.GeneratedCodeTargetFile;
+import org.coursera.courier.api.GeneratorRunnerOptions;
+import org.coursera.courier.api.PegasusCodeGenerator;
+import org.coursera.courier.lang.DocCommentStyle;
+import org.coursera.courier.lang.PoorMansCStyleSourceFormatter;
+import org.coursera.courier.py3.GlobalConfig;
+import org.coursera.courier.py3.Py3Properties;
+import org.coursera.courier.py3.Py3Syntax;
+import org.rythmengine.RythmEngine;
+import org.rythmengine.conf.RythmConfigurationKey;
+import org.rythmengine.exception.RythmException;
+import org.rythmengine.resource.ClasspathResourceLoader;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Properties;
+
+/**
+ * Courier code generator for Typescript.
+ */
+public class Python3Generator implements PegasusCodeGenerator {
+  private static final Py3Properties.Optionality defaultOptionality =
+      Py3Properties.Optionality.REQUIRED_FIELDS_MAY_BE_ABSENT;
+
+  private final GlobalConfig globalConfig;
+  private final RythmEngine engine;
+
+  public static void main(String[] args) throws Throwable {
+    // TODO(jbetz): use a CLI parser library
+
+    if (args.length < 3 || args.length > 5) {
+      throw new IllegalArgumentException(
+          "Usage: targetPath resolverPath1[:resolverPath2]+ sourcePath1[:sourcePath2]+ [REQUIRED_FIELDS_MAY_BE_ABSENT|STRICT] [EQUATABLE]");
+    }
+    String targetPath = args[0];
+    String resolverPath = args[1];
+    String sourcePathString = args[2];
+    String[] sourcePaths = sourcePathString.split(":");
+
+    Py3Properties.Optionality optionality = defaultOptionality;
+    if (args.length > 3) {
+      optionality = Py3Properties.Optionality.valueOf(args[3]);
+    }
+
+    boolean equatable = false;
+    if (args.length > 4) {
+      if (!args[4].equals("EQUATABLE")) {
+        throw new IllegalArgumentException("If present 4th argument must be 'EQUATABLE'");
+      }
+      equatable = true;
+    }
+
+    GeneratorRunnerOptions options =
+        new GeneratorRunnerOptions(targetPath, sourcePaths, resolverPath);
+
+    GlobalConfig globalConfig = new GlobalConfig(optionality, equatable, false);
+    GeneratorResult result =
+      new DefaultGeneratorRunner().run(new Python3Generator(globalConfig), options);
+
+    for (File file: result.getTargetFiles()) {
+      System.out.println(file.getAbsolutePath());
+    }
+
+    InputStream runtime = Python3Generator.class.getClassLoader().getResourceAsStream("runtime/courier.py");
+    IOUtils.copy(runtime, new FileOutputStream(new File(targetPath, "courier.py")));
+  }
+
+  public Python3Generator() {
+    this(new GlobalConfig(
+        defaultOptionality,
+        false,
+        false));
+  }
+
+  public Python3Generator(GlobalConfig globalConfig) {
+    this.globalConfig = globalConfig;
+    Properties props = new Properties();
+    props.setProperty(RythmConfigurationKey.CODEGEN_COMPACT_ENABLED.getKey(), "false");
+    this.engine = new RythmEngine(props);
+    this.engine.registerResourceLoader(new ClasspathResourceLoader(engine, "/"));
+  }
+
+  public static class Py3CompilationUnit extends GeneratedCodeTargetFile {
+    public Py3CompilationUnit(String name, String namespace) {
+      super(Py3Syntax.escapeKeyword(name, Py3Syntax.EscapeStrategy.MANGLE), namespace, "py");
+    }
+  }
+
+  public static class Py3GeneratedCode extends GeneratedCode {
+    public Py3GeneratedCode(GeneratedCodeTargetFile target, String code) {
+      super(target, code);
+    }
+  }
+
+  /**
+   * See {@link Py3Properties} for customization options.
+   */
+  @Override
+  public GeneratedCode generate(ClassTemplateSpec templateSpec) {
+
+    String code;
+    Py3Properties Py3Properties = globalConfig.lookupPy3Properties(templateSpec);
+    if (Py3Properties.omit) return null;
+
+    Py3Syntax syntax = new Py3Syntax(Py3Properties);
+    try {
+      if (templateSpec instanceof RecordTemplateSpec) {
+        code = engine.render("rythm-py3/record.txt", syntax.new Py3RecordSyntax((RecordTemplateSpec) templateSpec));
+      } else if (templateSpec instanceof EnumTemplateSpec) {
+        code = engine.render("rythm-py3/enum.txt", syntax.new Py3EnumSyntax((EnumTemplateSpec) templateSpec));
+      } else if (templateSpec instanceof UnionTemplateSpec) {
+        code = engine.render("rythm-py3/union.txt", syntax.new Py3UnionSyntax((UnionTemplateSpec) templateSpec));
+      } else if (templateSpec instanceof TyperefTemplateSpec) {
+        TyperefTemplateSpec typerefSpec = (TyperefTemplateSpec) templateSpec;
+        code = engine.render("rythm-py3/typeref.txt", syntax.Py3TyperefSyntaxCreate(typerefSpec));
+      } else if (templateSpec instanceof FixedTemplateSpec) {
+        code = engine.render("rythm-py3/fixed.txt", syntax.Py3FixedSyntaxCreate((FixedTemplateSpec) templateSpec));
+      } else {
+        return null; // Indicates that we are declining to generate code for the type (e.g. map or array)
+      }
+    } catch (RythmException e) {
+      throw new RuntimeException(
+        "Internal error in generator while processing " + templateSpec.getFullName(), e);
+    }
+    Py3CompilationUnit compilationUnit =
+        new Py3CompilationUnit(
+            templateSpec.getClassName(), templateSpec.getNamespace());
+
+    return new Py3GeneratedCode(compilationUnit, code);
+  }
+
+  @Override
+  public Collection<GeneratedCode> generatePredef() {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public Collection<DataSchema> definedSchemas() {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public String buildLanguage() {
+    return "python3";
+  }
+
+  @Override
+  public String customTypeLanguage() {
+    return "python3";
+  }
+}

--- a/python3/generator/src/main/java/org/coursera/courier/py3/GlobalConfig.java
+++ b/python3/generator/src/main/java/org/coursera/courier/py3/GlobalConfig.java
@@ -1,0 +1,47 @@
+package org.coursera.courier.py3;
+
+import com.linkedin.data.DataMap;
+import com.linkedin.data.schema.DataSchema;
+import com.linkedin.pegasus.generator.spec.ClassTemplateSpec;
+import com.linkedin.pegasus.generator.spec.UnionTemplateSpec;
+
+public class GlobalConfig {
+  public final Py3Properties defaults;
+
+  public GlobalConfig(
+      Py3Properties.Optionality defaultOptionality,
+      boolean defaultEquatable,
+      boolean defaultOmit) {
+    defaults = new Py3Properties(defaultOptionality, defaultEquatable, defaultOmit);
+  }
+
+  public Py3Properties lookupPy3Properties(ClassTemplateSpec templateSpec) {
+    DataSchema schema = templateSpec.getSchema();
+    if (templateSpec instanceof UnionTemplateSpec && templateSpec.getOriginalTyperefSchema() != null) {
+      schema = templateSpec.getOriginalTyperefSchema();
+    }
+
+    if (schema == null) {
+      return defaults;
+    } else {
+      Object typescript = schema.getProperties().get("python3");
+      if (typescript == null || !(typescript instanceof DataMap)) {
+        return defaults;
+      }
+      DataMap properties = ((DataMap) typescript);
+
+      String optionalityString = properties.getString("optionality");
+
+      Py3Properties.Optionality optionality =
+          optionalityString == null ? defaults.optionality : Py3Properties.Optionality.valueOf(optionalityString);
+
+      Boolean maybeEquatable = properties.getBoolean("equatable");
+      boolean equatable =  maybeEquatable == null ? defaults.equatable : maybeEquatable;
+
+      Boolean maybeOmit = properties.getBoolean("omit");
+      boolean omit = maybeOmit == null ? defaults.omit : maybeOmit;
+
+      return new Py3Properties(optionality, equatable, omit);
+    }
+  }
+}

--- a/python3/generator/src/main/java/org/coursera/courier/py3/Py3Properties.java
+++ b/python3/generator/src/main/java/org/coursera/courier/py3/Py3Properties.java
@@ -1,0 +1,67 @@
+package org.coursera.courier.py3;
+
+/**
+ * Customizable properties that may be added to a Pegasus schema.
+ *
+ * Example usage:
+ *
+ * <code>
+ *   {
+ *     "name": "Fortune",
+ *     "namespace": "org.example",
+ *     "type": "record",
+ *     "fields": [ ... ],
+ *     "typescript": {
+ *       "optionality": "STRICT"
+ *     }
+ *   }
+ * </code>
+ */
+public class Py3Properties {
+
+  /**
+   * "optionality" property.
+   *
+   * Typescript representations of Pegasus primitive types supported by this generator.
+   */
+  public enum Optionality {
+
+    /**
+     * Allows required fields to be absent, useful when working with projections.
+     *
+     * "undefined" is used to represent un-projected fields (required or optional) as well as absent
+     * optional fields.
+     */
+    REQUIRED_FIELDS_MAY_BE_ABSENT,
+
+    // TODO(jbetz): Remove as soon as we've migrated away from this usage pattern.
+    /**
+     * WARNING: this mode is unsafe when used in conjunction with projections, as a read/modify/coercerOutput
+     * pattern on a projection could result in the default value of primitives (e.g. 0 for ints)
+     * to be accidentally written.
+     *
+     * Required fields generated as non-optional Typescript properties.
+     *
+     * Optional fields are generated as optional Typescript properties, where an absent optional field
+     * value is represented as `nil`.
+     *
+     * When reading JSON, if a required field is absent, the field in data binding
+     * will default to the schema defined default value.
+     *
+     * When writing JSON, all required primitive fields will be written, even if they are the
+     * schema defined default value.
+     */
+    STRICT
+  }
+
+  public final Optionality optionality;
+  public final boolean equatable;
+  public final boolean omit;
+
+  public Py3Properties(Optionality optionality, boolean equatable, boolean omit) {
+    this.optionality = optionality;
+    this.equatable = equatable;
+    this.omit = omit;
+  }
+
+}

--- a/python3/generator/src/main/java/org/coursera/courier/py3/Py3Syntax.java
+++ b/python3/generator/src/main/java/org/coursera/courier/py3/Py3Syntax.java
@@ -203,7 +203,6 @@ public class Py3Syntax {
     }
 
     static Py3Import COURIER_RUNTIME = new Py3Import("courier", "", ImportStrategy.MODULE_AS_SELF);
-
     public static enum ImportStrategy {
       TYPE_FROM_EPONYMOUS_MODULE, MODULE_AS_SELF
     }
@@ -221,9 +220,7 @@ public class Py3Syntax {
     if (doc != null && !"".equals(doc)) {
       StringBuilder docStr = new StringBuilder(TRIPLE_QUOTE);
 
-      if (doc != null) {
-        docStr.append(doc.trim());
-      }
+      docStr.append(doc.trim());
 
       if (deprecation != null) {
         docStr.append("\n\n").append("@deprecated");
@@ -1205,6 +1202,10 @@ public class Py3Syntax {
         symbols.add(new Py3EnumSymbolSyntax(_template, _dataSchema, symbol));
       }
       return symbols;
+    }
+
+    public String imports() {
+      return Py3Import.COURIER_RUNTIME.relativeImport(this._dataSchema.getNamespace());
     }
 
     private String _interleaveSymbolStrings(String delimiter) {

--- a/python3/generator/src/main/java/org/coursera/courier/py3/Py3Syntax.java
+++ b/python3/generator/src/main/java/org/coursera/courier/py3/Py3Syntax.java
@@ -1,0 +1,1222 @@
+/*
+ * Copyright 2016 Coursera Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.coursera.courier.py3;
+
+import com.linkedin.data.DataMap;
+import com.linkedin.data.avro.SchemaTranslator;
+import com.linkedin.data.schema.DataSchema;
+import com.linkedin.data.schema.DataSchema.Type;
+import com.linkedin.data.schema.EnumDataSchema;
+import com.linkedin.data.schema.NamedDataSchema;
+import com.linkedin.data.schema.PrimitiveDataSchema;
+import com.linkedin.data.schema.RecordDataSchema;
+import com.linkedin.data.schema.TyperefDataSchema;
+import com.linkedin.data.schema.UnionDataSchema;
+import com.linkedin.pegasus.generator.spec.*;
+import org.coursera.courier.api.ClassTemplateSpecs;
+
+import java.util.*;
+
+/**
+ * Main work-horse for populating the ts-lite Rythm templates.
+ *
+ * Most work delegates to inner classes, so you probably want to look them (linked below)
+ *
+ * Specifically, {@link Py3EnumSyntax}, {@link Py3UnionSyntax}, {@link Py3RecordSyntax}, and {@link Py3TyperefSyntax} are
+ * used directly to populate the templates.
+ *
+ * @see Py3PrimitiveTypeSyntax
+ * @see Py3EnumSyntax
+ * @see Py3ArraySyntax
+ * @see Py3MapSyntax
+ * @see Py3TyperefSyntax
+ * @see Py3RecordSyntax
+ * @see Py3FixedSyntax
+ * @see Py3RecordSyntax
+ * @see Py3UnionSyntax
+ */
+public class Py3Syntax {
+
+  /** Config properties passed from the command line parser */
+  private final Py3Properties Py3Properties;
+  private static String TRIPLE_QUOTE = "\"\"\"";
+
+  public Py3Syntax(Py3Properties Py3Properties) {
+    this.Py3Properties = Py3Properties;
+  }
+
+  /**
+   * Varying levels of reserved keywords copied from https://docs.python.org/3.3/reference/lexical_analysis.html
+   **/
+  private static final Set<String> tsKeywords = new HashSet<String>(Arrays.asList(new String[]{
+    // Python-Reserved Words
+    "False",
+    "class",
+    "finally",
+    "is",
+    "return",
+    "None",
+    "continue",
+    "for",
+    "lambda",
+    "try",
+    "True",
+    "def",
+    "from",
+    "nonlocal",
+    "while",
+    "and",
+    "del",
+    "global",
+    "not",
+    "with",
+    "as",
+    "elif",
+    "if",
+    "or",
+    "yield",
+    "assert",
+    "else",
+    "import",
+    "pass",
+    "break",
+    "except",
+    "in",
+    "raise",
+
+    // Keywords reserved by this implementation
+    "data"
+  }));
+
+
+  /** Different choices for how to escaping symbols that match reserved ts keywords. */
+  public static enum EscapeStrategy {
+    /** Adds an underscore sign after the symbol name when escaping. e.g.: class becomes class$ */
+    MANGLE
+  }
+
+  /**
+   * Returns the escaped Pegasus symbol for use in Typescript source code.
+   *
+   * Pegasus symbols must be of the form [A-Za-z_], so this routine simply checks if the
+   * symbol collides with a typescript keyword, and if so, escapes it.
+   *
+   * @param symbol the symbol to escape
+   * @param strategy which strategy to use in escaping
+   *
+   * @return the escaped Pegasus symbol.
+   */
+  public static String escapeKeyword(String symbol, EscapeStrategy strategy) {
+    if (tsKeywords.contains(symbol)) {
+      if (strategy.equals(EscapeStrategy.MANGLE)) {
+        return symbol + "_";
+      } else {
+        return "\"" + symbol + "\"";
+      }
+    } else {
+      return symbol;
+    }
+  }
+
+  private static class Py3Import {
+    private final String _symbolToImport;
+    private final String _moduleToImport;
+    private final ImportStrategy _importStrategy;
+
+    public Py3Import(String symbolToImport, String moduleToImport, ImportStrategy importStrategy) {
+      this._symbolToImport = symbolToImport;
+      this._moduleToImport = moduleToImport;
+      this._importStrategy = importStrategy;
+    }
+
+    public String relativeImport(String importingNamespace) {
+      importingNamespace = importingNamespace == null? "": importingNamespace;
+      int termsInImportingNamespace = importingNamespace.isEmpty()? 0: importingNamespace.split("\\.").length;
+
+      StringBuilder dotsBuilder = new StringBuilder(".");
+      for (int i = 0; i < termsInImportingNamespace; i++) {
+        dotsBuilder.append('.');
+      }
+      String dots = dotsBuilder.toString();
+
+      String importString;
+      switch (this._importStrategy) {
+        case MODULE_AS_SELF:
+          importString = "from " + dots + " import " + this._symbolToImport + " as " + this._symbolToImport;
+          break;
+        case TYPE_FROM_EPONYMOUS_MODULE:
+          importString = "from " + dots + this._moduleToImport + "." + this._symbolToImport + " import " + this._symbolToImport;
+          break;
+        default:
+          throw new IllegalArgumentException(this._importStrategy + " is not a valid strategy");
+      }
+      return importString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      Py3Import that = (Py3Import) o;
+
+      if (!_symbolToImport.equals(that._symbolToImport)) return false;
+      return _moduleToImport.equals(that._moduleToImport);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = _symbolToImport.hashCode();
+      result = 31 * result + _moduleToImport.hashCode();
+      return result;
+    }
+
+    /**
+     * Takes a set of imports constructed with {@link #importString}, and produces a valid import block
+     * for use at the top of a typescript source file
+     *
+     * @param imports the set of imports, each of which is a valid import line in typescript
+     * @return the import block, on separate lines.
+     */
+    public static String relativeImportBlock(Collection<Py3Import> imports, String importingNamespace) {
+      StringBuilder sb = new StringBuilder();
+
+      for (Py3Import import_: imports) {
+        sb.append(import_.relativeImport(importingNamespace)).append("\n");
+      }
+
+      return sb.toString();
+    }
+
+    static Py3Import COURIER_RUNTIME = new Py3Import("courier", "", ImportStrategy.MODULE_AS_SELF);
+
+    public static enum ImportStrategy {
+      TYPE_FROM_EPONYMOUS_MODULE, MODULE_AS_SELF
+    }
+  }
+
+  /**
+   * Return a full tsdoc for a type.
+   *
+   * @param doc the doc string in the type's DataSchema.
+   * @param deprecation the object listed under the schema's "deprecation" property
+   *
+   * @return a fully formed tsdoc for the type.
+   */
+  private static String docComment(String doc, Object deprecation /* nullable */) {
+    if (doc != null && !"".equals(doc)) {
+      StringBuilder docStr = new StringBuilder(TRIPLE_QUOTE);
+
+      if (doc != null) {
+        docStr.append(doc.trim());
+      }
+
+      if (deprecation != null) {
+        docStr.append("\n\n").append("@deprecated");
+        if (deprecation instanceof String) {
+          docStr.append("  ").append(((String)deprecation).trim());
+        }
+      }
+      docStr.append(TRIPLE_QUOTE);
+
+      return docStr.toString();
+    } else {
+      return "";
+    }
+  }
+
+  private String _toAvroSchemaJsonSafe(DataSchema dataSchema) {
+    try {
+      return _tripleQuote(SchemaTranslator.dataToAvroSchemaJson(dataSchema));
+    } catch (Exception e) {
+      e.printStackTrace();
+      return "\"\"";
+    }
+  }
+
+  /** Describes any type we are representing in the generated python */
+  interface Py3TypeSyntax {
+
+    /** Return the simple name of the type, in valid typescript. "number" or "string" for example. */
+    public String typeName();
+
+    public String constructor();
+
+    /**
+     * Return the set of modules that must be imported in order for some other module
+     * to use this type.
+     **/
+    public Set<Py3Import> modulesRequiredToUse();
+  }
+
+  /**
+   * Describes any type that can be enclosed by another. According to the restli spec this only applies
+   * to anonymous unions. https://github.com/linkedin/rest.li/wiki/DATA-Data-Schema-and-Templates
+   **/
+  private interface Py3EnclosedTypeSyntax {
+    public String typeNameQualifiedByEnclosedType();
+    public String constructorQualifiedByEnclosedType();
+  }
+
+  private interface Py3CollectionSyntax {
+    public String collectionTypeName();
+  }
+
+  /**
+   * Create a Py3*Syntax class around the provided ClassTemplate.
+   *
+   * That class will perform the heavy lifting of rendering Py3-specific strings into the template.
+   *
+   * @param template the ClassTemplate
+   * @return a Py3*Syntax class (see {@link Py3Syntax} class-level docs for more info)
+   */
+  private Py3TypeSyntax createTypeSyntax(ClassTemplateSpec template) {
+    if (template instanceof RecordTemplateSpec) {
+      return new Py3RecordSyntax((RecordTemplateSpec) template);
+    } else if (template instanceof TyperefTemplateSpec) {
+      return Py3TyperefSyntaxCreate((TyperefTemplateSpec) template);
+    } else if (template instanceof FixedTemplateSpec) {
+      return Py3FixedSyntaxCreate((FixedTemplateSpec) template);
+    } else if (template instanceof EnumTemplateSpec) {
+      return new Py3EnumSyntax((EnumTemplateSpec) template);
+    } else if (template instanceof PrimitiveTemplateSpec) {
+      return new Py3PrimitiveTypeSyntax((PrimitiveTemplateSpec) template);
+    } else if (template instanceof MapTemplateSpec) {
+      return new Py3MapSyntax((MapTemplateSpec) template);
+    } else if (template instanceof ArrayTemplateSpec) {
+      return new Py3ArraySyntax((ArrayTemplateSpec) template);
+    } else if (template instanceof UnionTemplateSpec) {
+      return new Py3UnionSyntax((UnionTemplateSpec) template);
+    } else {
+      throw new RuntimeException("Unrecognized template spec: " + template + " with schema " + template.getSchema());
+    }
+  }
+
+  /** Convenience wrapper around {@link #createTypeSyntax(ClassTemplateSpec)}. */
+  private Py3TypeSyntax createTypeSyntax(DataSchema schema) {
+    return createTypeSyntax(ClassTemplateSpec.createFromDataSchema(schema));
+  }
+
+  /**
+   * Returns the type name, prefaced with the enclosing class name if there was one.
+   *
+   * For example, a standalone union called MyUnion will just return "MyUnion".
+   * If that same union were enclosed within MyRecord, this would return "MyRecord.MyUnion".
+   **/
+  String typeNameQualifiedByEnclosingClass(Py3TypeSyntax syntax) {
+    if (syntax instanceof Py3EnclosedTypeSyntax) {
+      return ((Py3EnclosedTypeSyntax) syntax).typeNameQualifiedByEnclosedType();
+    } else {
+      return syntax.typeName();
+    }
+  }
+
+  String constructorQualifiedByEnclosingClass(Py3TypeSyntax syntax) {
+    if (syntax instanceof Py3EnclosedTypeSyntax) {
+      return ((Py3EnclosedTypeSyntax) syntax).constructorQualifiedByEnclosedType();
+    } else {
+      return syntax.constructor();
+    }
+  }
+
+  private String _tripleQuote(String toQuote) {
+    return TRIPLE_QUOTE + toQuote + TRIPLE_QUOTE;
+  }
+
+  /** Py3-specific syntax for Maps */
+  private class Py3MapSyntax implements Py3TypeSyntax, Py3CollectionSyntax {
+    private final MapTemplateSpec _template;
+
+    Py3MapSyntax(MapTemplateSpec _template) {
+      this._template = _template;
+    }
+
+    @Override
+    public String typeName() {
+      // (This comment is duplicated from Py3ArraySyntax.typeName for your benefit)
+      // Sadly the behavior of this function is indirectly controlled by the one calling it: Py3RecordFieldSyntax.
+      // That class has the unfortunate behavior that it can produce 2 different ClassTemplateSpecs, one of which works for
+      // some cases, and one of which works for the others. See its own "typeName" definition for details but essentially
+      // it will give us one of the ClassTemplateSpecs and call typeName. If we then return null
+      // then it will give it a shot with the other ClassTemplateSpec. Unfortunately we have to do this because if
+      // we try to just use the first one, we will return "Map<null>". This is also why we special-case unions here.
+      // we have to access a specific ClassTemplate
+      boolean valueIsUnion = _template.getValueClass() instanceof UnionTemplateSpec;
+      Py3TypeSyntax itemTypeSyntax = valueIsUnion? createTypeSyntax(_template.getValueClass()): _valueTypeSyntax();
+      String valueTypeName = typeNameQualifiedByEnclosingClass(itemTypeSyntax);
+      return valueTypeName == null? null: valueTypeName;
+    }
+
+    @Override
+    public String collectionTypeName() {
+      return "map";
+    }
+
+    @Override
+    public String constructor() {
+      // Sadly the behavior of this function is indirectly controlled by the one calling it: Py3RecordFieldSyntax.
+      // That class has the unfortunate behavior that it can produce 2 different ClassTemplateSpecs, one of which works for
+      // some cases, and one of which works for the others. See its own "typeName" definition for details but essentially
+      // it will give us one of the ClassTemplateSpecs and call typeName. If we then return null
+      // then it will give it a shot with the other ClassTemplateSpec. Unfortunately we have to do this because if
+      // we try to just use the first one, we will return "Array<null>". This is also why we special-case unions here.
+      // we have to access a specific ClassTemplate
+      boolean itemIsUnion = _template.getValueClass() instanceof UnionTemplateSpec;
+      Py3TypeSyntax itemTypeSyntax = itemIsUnion? createTypeSyntax(_template.getValueClass()): _valueTypeSyntax();
+      String itemTypeName = typeNameQualifiedByEnclosingClass(itemTypeSyntax);
+      return itemTypeName == null? null: "courier.map(" + itemTypeName + ")";
+    }
+
+    @Override
+    public Set<Py3Import> modulesRequiredToUse() {
+      Set<Py3Import> requiredForUse = new HashSet<>();
+
+      requiredForUse.addAll(_valueTypeSyntax().modulesRequiredToUse());
+      requiredForUse.add(Py3Import.COURIER_RUNTIME);
+
+      return requiredForUse;
+    }
+
+    //
+    // Private Py3MapSyntax members
+    //
+    private Py3TypeSyntax _valueTypeSyntax() {
+      return createTypeSyntax(_template.getSchema().getValues());
+    }
+  }
+
+  /** Py3-specific syntax for Arrays */
+  private class Py3ArraySyntax implements Py3TypeSyntax, Py3CollectionSyntax {
+    private final ArrayTemplateSpec _template;
+
+    Py3ArraySyntax(ArrayTemplateSpec _template) {
+      this._template = _template;
+    }
+
+    @Override
+    public String typeName() {
+      // Sadly the behavior of this function is indirectly controlled by the one calling it: Py3RecordFieldSyntax.
+      // That class has the unfortunate behavior that it can produce 2 different ClassTemplateSpecs, one of which works for
+      // some cases, and one of which works for the others. See its own "typeName" definition for details but essentially
+      // it will give us one of the ClassTemplateSpecs and call typeName. If we then return null
+      // then it will give it a shot with the other ClassTemplateSpec. Unfortunately we have to do this because if
+      // we try to just use the first one, we will return "Array<null>". This is also why we special-case unions here.
+      // we have to access a specific ClassTemplate
+      boolean itemIsUnion = _template.getItemClass() instanceof UnionTemplateSpec;
+      Py3TypeSyntax itemTypeSyntax = itemIsUnion? createTypeSyntax(_template.getItemClass()): _itemTypeSyntax();
+      String itemTypeName = typeNameQualifiedByEnclosingClass(itemTypeSyntax);
+      return itemTypeName == null? null: itemTypeName;
+    }
+
+    @Override
+    public String collectionTypeName() {
+      return "array";
+    }
+
+    @Override
+    public String constructor() {
+      // Sadly the behavior of this function is indirectly controlled by the one calling it: Py3RecordFieldSyntax.
+      // That class has the unfortunate behavior that it can produce 2 different ClassTemplateSpecs, one of which works for
+      // some cases, and one of which works for the others. See its own "typeName" definition for details but essentially
+      // it will give us one of the ClassTemplateSpecs and call typeName. If we then return null
+      // then it will give it a shot with the other ClassTemplateSpec. Unfortunately we have to do this because if
+      // we try to just use the first one, we will return "Array<null>". This is also why we special-case unions here.
+      // we have to access a specific ClassTemplate
+      boolean itemIsUnion = _template.getItemClass() instanceof UnionTemplateSpec;
+      Py3TypeSyntax itemTypeSyntax = itemIsUnion? createTypeSyntax(_template.getItemClass()): _itemTypeSyntax();
+      String itemTypeName = constructorQualifiedByEnclosingClass(itemTypeSyntax);
+      return itemTypeName == null? null: "courier.array(" + itemTypeName + ")";
+    }
+
+    @Override
+    public Set<Py3Import> modulesRequiredToUse() {
+      Set<Py3Import> requiredForUse = new HashSet<>();
+
+      requiredForUse.addAll(_itemTypeSyntax().modulesRequiredToUse());
+      requiredForUse.add(Py3Import.COURIER_RUNTIME);
+
+      return requiredForUse;
+    }
+
+    //
+    // Private Py3ArraySyntax members
+    //
+    private Py3TypeSyntax _itemTypeSyntax() {
+      return createTypeSyntax(_template.getSchema().getItems());
+    }
+  }
+
+  /** Pegasus types that should be rendered as "number" in typescript */
+  private static final Set<Type> Py3_NUMBER_TYPES = new HashSet<>(
+      Arrays.asList(
+          new Type[] { Type.INT, Type.LONG, Type.FLOAT, Type.DOUBLE }
+      )
+  );
+
+  /** Pegasus types that should be rendered as "string" in typescript */
+  private static final Set<Type> Py3_STRING_TYPES = new HashSet<>(
+      Arrays.asList(
+          new Type[] { Type.STRING, Type.BYTES, Type.FIXED }
+      )
+  );
+
+  /** Py3-specific syntax for all primitive types: Integer, Long, Float, Double, Boolean, String, Byte. */
+  private class Py3PrimitiveTypeSyntax implements Py3TypeSyntax {
+    private final PrimitiveTemplateSpec _template;
+    private final PrimitiveDataSchema _schema;
+
+    Py3PrimitiveTypeSyntax(PrimitiveTemplateSpec _template) {
+      this._template = _template;
+      this._schema = _template.getSchema();
+    }
+
+    @Override
+    public String typeName() {
+      Type schemaType = _schema.getType();
+      if (schemaType == Type.INT || schemaType == Type.LONG) {
+        return "int"; // unlike py2, py3 has no 'long' type
+      } else if (schemaType == Type.DOUBLE) {
+        return "float";
+      } else if (schemaType == Type.FLOAT) {
+        return "float";
+      } else if (Py3_STRING_TYPES.contains(schemaType)) {
+        return "str";
+      } else if (schemaType == Type.BOOLEAN) {
+        return "bool";
+      } else {
+        throw new IllegalArgumentException("Unexpected type " + schemaType + " in schema " + _schema);
+      }
+    }
+
+    @Override
+    public String constructor() {
+      return this.typeName();
+    }
+
+    @Override
+    public Set<Py3Import> modulesRequiredToUse() {
+      return new HashSet<>(); // using a primitive requires no imports
+    }
+  }
+
+  /**
+   * Helper class that more-or-less wraps {@link NamedDataSchema}.
+   *
+   * Helps reduce code bloat for Records, Enums, and Typerefs.
+   **/
+  private class Py3NamedTypeSyntax {
+    private final NamedDataSchema _dataSchema;
+
+    public Py3NamedTypeSyntax(NamedDataSchema _dataSchema) {
+      this._dataSchema = _dataSchema;
+    }
+
+    public String typeName() {
+      return Py3Syntax.escapeKeyword(this._dataSchema.getName(), EscapeStrategy.MANGLE);
+    }
+
+    public String docString() {
+      return docComment(
+          _dataSchema.getDoc(),
+          _dataSchema.getProperties().get("deprecated")
+      );
+    }
+
+    public Set<Py3Import> modulesRequiredToUse() {
+      Set<Py3Import> modules = new HashSet<>();
+      // Named types get their own files, so you have to import them in order to use them.
+      Py3Import theImport = new Py3Import(
+        _dataSchema.getName(),
+        _dataSchema.getNamespace(),
+        Py3Import.ImportStrategy.TYPE_FROM_EPONYMOUS_MODULE
+      );
+      modules.add(theImport);
+      return modules;
+    }
+  }
+
+  /** Py3 syntax for Fixed types. */
+  public class Py3FixedSyntax  implements Py3TypeSyntax {
+    private final FixedTemplateSpec _template;
+    private final Py3NamedTypeSyntax _namedSyntax;
+
+    public Py3FixedSyntax(FixedTemplateSpec template, Py3NamedTypeSyntax namedSyntax) {
+      this._template = template;
+      this._namedSyntax = namedSyntax;
+    }
+
+    public String docString() {
+      return _namedSyntax.docString();
+    }
+
+    public String typeName() {
+      return _namedSyntax.typeName();
+    }
+
+    @Override
+    public String constructor() {
+      return this.typeName();
+    }
+
+    @Override
+    public Set<Py3Import> modulesRequiredToUse() {
+      return _namedSyntax.modulesRequiredToUse();
+    }
+  }
+
+  /** Create a new Py3FixedSyntax */
+  public Py3FixedSyntax Py3FixedSyntaxCreate(FixedTemplateSpec template) {
+    return new Py3FixedSyntax(template, new Py3NamedTypeSyntax(template.getSchema()));
+  }
+
+  /**
+   * Py3 representation of a Union type's member (e.g. the "int" in "union[int]").
+   */
+  public class Py3UnionMemberSyntax {
+    private final Py3UnionSyntax _parentSyntax;
+    private final UnionDataSchema _schema;
+    private final UnionTemplateSpec.Member _member;
+
+    public Py3UnionMemberSyntax(Py3UnionSyntax _parentSyntax, UnionDataSchema _schema, UnionTemplateSpec.Member _member) {
+      this._parentSyntax = _parentSyntax;
+      this._schema = _schema;
+      this._member = _member;
+    }
+
+    /**
+     * Provides a partially-qualified representation of this type's "Member" sister.
+     * For example, if you had a courier union[int] typeref as "MyUnion", this method would
+     * return "MyUnion.IntMember".
+     **/
+    String fullUnionMemberTypeName() {
+      return _parentSyntax.typeName() + "." + this.unionMemberTypeName();
+    }
+
+    /**
+     * Returns the symbol used to access this union member's index in the union's "unpack" return object.
+     *
+     * For example, given union[FortuneCookie], the return object from "unpack" would be { fortuneCookie: union["namespace.FortuneCookie"] as FortuneCookie }
+     */
+    public String unpackString() {
+      DataSchema schema = _memberSchema();
+      String unpackNameBase;
+      if (schema instanceof PrimitiveDataSchema) {
+        unpackNameBase = schema.getUnionMemberKey();
+      } else {
+        unpackNameBase = _memberTypeSyntax().typeName();
+      }
+
+      String punctuationEscaped = unpackNameBase.replaceAll("[\\p{Punct}\\p{Space}]", "");
+      String lowerCased = Character.toLowerCase(punctuationEscaped.charAt(0)) + punctuationEscaped.substring(1);
+
+      return escapeKeyword(lowerCased, EscapeStrategy.MANGLE);
+    }
+
+    /**
+     * Returns the union member class name for the given {@link ClassTemplateSpec} as a Typescript
+     * source code string.
+     *
+     * @return a typescript source code string identifying the union member.
+     */
+    public String unionMemberTypeName() {
+      DataSchema memberSchema = _memberSchema();
+      Type memberType = _memberSchema().getType();
+      if (memberSchema.isPrimitive() || memberType == Type.MAP || memberType == Type.ARRAY) {
+        String unionMemberKey = _memberSchema().getUnionMemberKey();
+        String camelCasedName = Character.toUpperCase(unionMemberKey.charAt(0)) + unionMemberKey.substring(1);
+        return camelCasedName + "Member"; // IntMember, DoubleMember, FixedMember etc
+      } else if (memberSchema instanceof NamedDataSchema) {
+        String className = ((NamedDataSchema) memberSchema).getName();
+        return className + "Member"; // e.g: FortuneCookieMember
+      } else {
+        throw new IllegalArgumentException("Don't know how to handle schema of type " + memberSchema.getType());
+      }
+    }
+
+    public String unionMemberKey() {
+      return _member.getSchema().getUnionMemberKey();
+    }
+
+    public String typeName() {
+      return _memberTypeSyntax().typeName();
+    }
+
+    public String accessorName() {
+      String accessorTypeName = this.typeName();
+      Py3TypeSyntax memberSyntax = this._memberTypeSyntax();
+      if (memberSyntax instanceof Py3CollectionSyntax) {
+        accessorTypeName += "_" + ((Py3CollectionSyntax) memberSyntax).collectionTypeName();
+      }
+      return "as_" + accessorTypeName;
+    }
+    public String constructor() {
+      return _memberTypeSyntax().constructor();
+    }
+
+    /** The set of modules imports that need to be included in order to use the type represented by this union member */
+    Set<Py3Import> typeModules() {
+      return _memberTypeSyntax().modulesRequiredToUse();
+    }
+
+    //
+    // Private UnionMemberSyntax members
+    //
+    private DataSchema _memberSchema() {
+      return _member.getSchema();
+    }
+    private Py3TypeSyntax _memberTypeSyntax() {
+      return createTypeSyntax(_member.getSchema());
+    }
+  }
+
+  /** Py3-specific representation of a Union type. */
+  public class Py3UnionSyntax implements Py3TypeSyntax, Py3EnclosedTypeSyntax {
+    private final UnionTemplateSpec _template;
+    private final UnionDataSchema _schema;
+
+    public Py3UnionSyntax(UnionTemplateSpec _template) {
+      this._template = _template;
+      this._schema = _template.getSchema();
+    }
+
+    @Override
+    public String typeNameQualifiedByEnclosedType() {
+      if (_template.getEnclosingClass() != null) {
+        return createTypeSyntax(_template.getEnclosingClass()).typeName() + "." + this.typeName();
+      } else {
+        return this.typeName();
+      }
+    }
+
+    @Override
+    public String constructorQualifiedByEnclosedType() {
+      if (_template.getEnclosingClass() != null) {
+        return createTypeSyntax(_template.getEnclosingClass()).constructor() + "." + this.constructor();
+      } else {
+        return this.constructor();
+      }
+    }
+
+    @Override
+    public String typeName() {
+      if (_template.getTyperefClass() != null) {
+        // If this union was typerefed then just use the typeref name
+        Py3TyperefSyntax refSyntax = Py3TyperefSyntaxCreate(_template.getTyperefClass());
+        return refSyntax.typeName();
+      } else {
+        // I actually never figured out why this works, so I'm very sorry if you're dealing
+        // with the repercussions here.
+        return escapeKeyword(this._template.getClassName(), EscapeStrategy.MANGLE);
+      }
+    }
+
+    @Override
+    public String constructor() {
+      return this.typeName();
+    }
+
+    public String avroSchemaJson() {
+      return _toAvroSchemaJsonSafe(this._schema);
+    }
+
+    /** Return the whole python import block for the file in which this union is declared. */
+    public String imports() {
+      Set<Py3Import> allImports = new HashSet<>();
+
+      // Only print out the imports for non-enclosed union types. Enclosed ones will be handled
+      // by the enclosing record.
+      if (!_isEnclosedType()) {
+        allImports.add(Py3Import.COURIER_RUNTIME);
+
+        for (Py3UnionMemberSyntax member: this.members()) {
+          allImports.addAll(member.typeModules());
+        }
+
+      }
+
+      return Py3Import.relativeImportBlock(allImports, this._template.getNamespace());
+    }
+
+    @Override
+    public Set<Py3Import> modulesRequiredToUse() {
+      Set<Py3Import> modules = new HashSet<>();
+      // enclosed types dont report modules -- their enclosing types will do so for them!
+      if (!_isEnclosedType() && this.typeName() != null) {
+        modules.add(
+          new Py3Import(
+            this.typeName(),
+            this._template.getNamespace(),
+            Py3Import.ImportStrategy.TYPE_FROM_EPONYMOUS_MODULE
+          )
+        );
+      }
+      return modules;
+    }
+
+    public String docString() {
+      if (this._template.getTyperefClass() != null) {
+        return new Py3NamedTypeSyntax(this._template.getTyperefClass().getSchema()).docString();
+      } else {
+        return "";
+      }
+    }
+
+    /**
+     * Produces the "MyUnionMember" typename.
+     *
+     * For example, union[int, string] produces a few extra types: IntMember, StringMember, etc. Each of those inherit
+     * from "MyUnionMember" (or whatever your union type is called)
+     **/
+    public String memberBaseTypeName() {
+      return this.typeName() + "Member";
+    }
+
+    /**
+     * Given union[int, string, FortuneCookie] this returns the typescript equivalent: "number" | "string" | FortuneCookie
+     **/
+    public String unionTypeExpression() {
+      StringBuilder sb = new StringBuilder();
+
+      List<Py3UnionMemberSyntax> members = this.members();
+      for (int i = 0; i < members.size(); i++) {
+        boolean isLast = (i == members.size() - 1);
+        Py3UnionMemberSyntax member = members.get(i);
+        sb.append(member.typeName());
+
+        if (!isLast) {
+          sb.append(" | ");
+        }
+      }
+
+      return sb.toString();
+    }
+
+    /**
+     * The same as {@link #unionTypeExpression}, but for the *Member interfaces that provide string-lookup.
+     *
+     * So given union[int, string, FortuneCookie] this returns "MyUnion.IntMember | MyUnion.StringMember | MyUnion.FortuneCookieMember"
+     *
+     */
+    public String memberUnionTypeExpression() {
+      List<Py3UnionMemberSyntax> members = this.members();
+
+      if (members.isEmpty()) {
+        return "void";
+      } else {
+        StringBuilder sb = new StringBuilder();
+
+
+        for (int i = 0; i < members.size(); i++) {
+          boolean isLast = (i == members.size() - 1);
+          Py3UnionMemberSyntax member = members.get(i);
+          sb.append(member.fullUnionMemberTypeName());
+
+          if (!isLast) {
+            sb.append(" | ");
+          }
+        }
+
+        return sb.toString();
+      }
+    }
+
+    /** Return the syntax for each member */
+    public List<Py3UnionMemberSyntax> members() {
+      List<Py3UnionMemberSyntax> memberSyntax = new ArrayList<>();
+
+      for (UnionTemplateSpec.Member member : this._template.getMembers()) {
+        memberSyntax.add(new Py3UnionMemberSyntax(this, _schema, member));
+      }
+
+      return memberSyntax;
+    }
+
+    /** Returns true in the usual case that this isn't some stupid empty union. */
+    public boolean requiresCompanionModule() {
+      return !this._template.getMembers().isEmpty();
+    }
+
+    private boolean _isEnclosedType() {
+      return _template.getEnclosingClass() != null;
+    }
+  }
+
+  /** The Py3 representation of a single field in a Record */
+  public class Py3RecordFieldSyntax  implements Py3TypeSyntax {
+    private final RecordTemplateSpec _template;
+    private final RecordDataSchema _schema;
+    private final RecordTemplateSpec.Field _field;
+
+    public Py3RecordFieldSyntax(RecordTemplateSpec _template, RecordTemplateSpec.Field _field) {
+      this._template = _template;
+      this._schema = _template.getSchema();
+      this._field = _field;
+    }
+
+    @Override
+    public Set<Py3Import> modulesRequiredToUse() {
+      Set<Py3Import> modules = new HashSet<>();
+      // since this record lives in its own file you have to import it to use it.
+      modules.add(new Py3Import(this._schema.getNamespace(), this.typeName(), Py3Import.ImportStrategy.TYPE_FROM_EPONYMOUS_MODULE));
+      return modules;
+    }
+
+    /** The typescript property for getting this field. */
+    public String accessorName() {
+      return escapeKeyword(_schemaField().getName(), EscapeStrategy.MANGLE);
+    }
+
+    public String jsonKey() {
+      return _schemaField().getName();
+    }
+
+    public String typeName() {
+      return typeNameQualifiedByEnclosingClass(this._fieldSyntax());
+    }
+
+    @Override
+    public String constructor() {
+      return constructorQualifiedByEnclosingClass(this._fieldSyntax());
+    }
+
+    public String docString() {
+      return docComment(
+          _schemaField().getDoc(),
+          _schemaField().getProperties().get("deprecated")
+      );
+    }
+
+    /** The modules that the containing Record module has to import in order to compile. */
+    public Set<Py3Import> typeModules() {
+      return _fieldTypeSyntax().modulesRequiredToUse();
+    }
+
+    /**
+     * Just returns a "?" if this was an optional field either due to being decalred optional, or opting not to pass
+     * the STRICT directive into the generator.
+     **/
+    public String questionMarkIfOptional() {
+      boolean isFieldOptional = _schemaField().getOptional();
+      boolean markFieldAsOptional = isFieldOptional || Py3Properties.optionality == org.coursera.courier.py3.Py3Properties.Optionality.REQUIRED_FIELDS_MAY_BE_ABSENT;
+
+      return markFieldAsOptional? "?": "";
+    }
+
+    //
+    // Private members
+    //
+    private RecordDataSchema.Field _schemaField() {
+      return _field.getSchemaField();
+    }
+    private Py3TypeSyntax _fieldTypeSyntax() {
+      return createTypeSyntax(_schemaField().getType());
+    }
+    private Py3TypeSyntax _fieldSyntax() {
+      // To resolve type name we have to determine whether to use the DataSchema in _field.getType() or
+      // the one in _field.getSchemaField().getType(). We reach first for the schemaField as it does not swallow
+      // Typerefs. (e.g. if a type was defined as CustomInt, it will give us the string CustomInt, whereas
+      // field.getType() would dereference all the way to the bottom).
+      //
+      // The only problem with schemaField is that it _does_ swallow the type names for enclosed unions. ARGH
+      // can we catch a break?? Thankfully in the case of the enclosed union it ends up returning null, so
+      // we back off to _field.getType() if schemaField returned null.
+      Py3TypeSyntax candidateSyntax = createTypeSyntax(_schemaField().getType());
+      if (candidateSyntax.typeName() == null || "".equals(candidateSyntax)) {
+        candidateSyntax = createTypeSyntax(_field.getType());
+      }
+
+      return candidateSyntax;
+    }
+  }
+
+  /** Py3-specific syntax for Records */
+  public class Py3RecordSyntax implements Py3TypeSyntax {
+    private final RecordTemplateSpec _template;
+    private final RecordDataSchema _schema;
+    private final Py3NamedTypeSyntax _namedTypeSyntax;
+
+    public Py3RecordSyntax(RecordTemplateSpec _template) {
+      this._template = _template;
+      this._schema = _template.getSchema();
+      this._namedTypeSyntax = new Py3NamedTypeSyntax(_schema);
+    }
+
+    public String docString() {
+      return _namedTypeSyntax.docString();
+    }
+
+    public List<Py3RecordFieldSyntax> fields() {
+      List<Py3RecordFieldSyntax> fields = new ArrayList<>();
+
+      for (RecordTemplateSpec.Field fieldSpec: _template.getFields()) {
+        fields.add(new Py3RecordFieldSyntax(_template, fieldSpec));
+      }
+
+      return fields;
+    }
+
+    public Set<Py3UnionSyntax> enclosedUnions() {
+      Set<Py3UnionSyntax> unions = new HashSet<>();
+      for (ClassTemplateSpec spec: ClassTemplateSpecs.allContainedTypes(_template)) {
+        if (spec instanceof UnionTemplateSpec) {
+          unions.add(new Py3UnionSyntax((UnionTemplateSpec) spec));
+        }
+      }
+
+      return unions;
+    }
+
+    public String avroSchemaJson() {
+      return _toAvroSchemaJsonSafe(this._schema);
+    }
+
+    @Override
+    public Set<Py3Import> modulesRequiredToUse() {
+      return _namedTypeSyntax.modulesRequiredToUse();
+    }
+
+    public String typeName() {
+      return escapeKeyword(_schema.getName(), EscapeStrategy.MANGLE);
+    }
+
+    @Override
+    public String constructor() {
+      return this.typeName();
+    }
+
+    /**
+     * Returns true if a companion module needs to be declared for this record's interface. This is true if the record
+     * has enclosing types that must be defined within the record's namespace.
+     **/
+    public boolean requiresCompanionModule() {
+      return !ClassTemplateSpecs.allContainedTypes(_template).isEmpty();
+    }
+
+    /** The complete typescript import block for this record */
+    public String imports() {
+      Set<Py3Import> allImports = new HashSet<>();
+
+      allImports.add(Py3Import.COURIER_RUNTIME);
+      for (Py3RecordFieldSyntax fieldSyntax: this.fields()) {
+        allImports.addAll(fieldSyntax.typeModules());
+      }
+
+      for (Py3UnionSyntax union: this.enclosedUnions()) {
+        for (Py3UnionMemberSyntax unionMember: union.members()) {
+          allImports.addAll(unionMember.typeModules());
+        }
+      }
+
+      return Py3Import.relativeImportBlock(allImports, this._schema.getNamespace());
+    }
+  }
+
+  /** Py3 syntax for typerefs. */
+  public class Py3TyperefSyntax implements Py3TypeSyntax {
+    private final TyperefTemplateSpec _template;
+    private final TyperefDataSchema _dataSchema;
+    private final Py3NamedTypeSyntax _namedTypeSyntax;
+
+    public Py3TyperefSyntax(TyperefTemplateSpec _template, TyperefDataSchema _dataSchema, Py3NamedTypeSyntax _namedTypeSyntax) {
+      this._template = _template;
+      this._dataSchema = _dataSchema;
+      this._namedTypeSyntax = _namedTypeSyntax;
+    }
+
+    public String docString() {
+      return _namedTypeSyntax.docString();
+    }
+
+    @Override
+    public Set<Py3Import> modulesRequiredToUse() {
+      return _namedTypeSyntax.modulesRequiredToUse();
+    }
+
+    public String typeName() {
+      // Have to use _dataSchema.getName() instead of _template.getClassName() here because otherwise
+      // generics will return strings like Array<null> instead of Array<CustomTyperefName>. Not sure why??
+      return escapeKeyword(_dataSchema.getName(), EscapeStrategy.MANGLE);
+    }
+
+    @Override
+    public String constructor() {
+      return this.typeName();
+    }
+
+    /** The type that this typeref refers to. */
+    public String refTypeConstructor() {
+      return createTypeSyntax(_refType()).constructor();
+    }
+
+    /** Import block for this typeref's module file */
+    public String imports() {
+      // Gotta import the referenced type in order to compile this typeref's own module
+      Set<Py3Import> refTypeImport = createTypeSyntax(_refType()).modulesRequiredToUse();
+      return Py3Import.relativeImportBlock(refTypeImport, this._template.getNamespace());
+    }
+
+    //
+    // Private members
+    //
+    private ClassTemplateSpec _refType() {
+      return ClassTemplateSpec.createFromDataSchema(_dataSchema.getRef());
+    }
+  }
+
+  /** Create a new TyperefSyntax */
+  public Py3TyperefSyntax Py3TyperefSyntaxCreate(TyperefTemplateSpec template) {
+    return new Py3TyperefSyntax(template, template.getSchema(), new Py3NamedTypeSyntax(template.getSchema()));
+  }
+
+  /** Py3 syntax for the symbol of an enum */
+  public class Py3EnumSymbolSyntax {
+    private final EnumTemplateSpec _template;
+    private final EnumDataSchema _dataSchema;
+    private final String _symbolString;
+
+    public Py3EnumSymbolSyntax(EnumTemplateSpec _template, EnumDataSchema _dataSchema, String _symbolString) {
+      this._template = _template;
+      this._dataSchema = _dataSchema;
+      this._symbolString = _symbolString;
+    }
+
+    /**
+     * Returns the quoted value that will be transmitted for this enum over the wire.
+     *
+     * Used to make a string-literal union representing the enum.
+     **/
+    public String stringLiteralValue() {
+      return "\"" + _symbolString + "\"";
+    }
+
+    /**
+     * Returns a variable name that can represent the enum value. Will be used to make something like
+     * const PINEAPPLE: Fruits = "PINEAPPLE";
+     */
+    public String moduleConstValue() {
+      return escapeKeyword(_symbolString, EscapeStrategy.MANGLE);
+    }
+
+    public String docString() {
+      String symbolDoc = _dataSchema.getSymbolDocs().get(_symbolString);
+      DataMap deprecatedSymbols = (DataMap) _dataSchema.getProperties().get("deprecatedSymbols");
+      Object symbolDeprecation = null;
+
+      if (deprecatedSymbols != null) {
+        symbolDeprecation = deprecatedSymbols.get(_symbolString);
+      }
+      return docComment(
+          symbolDoc,
+          symbolDeprecation
+      );
+    }
+  }
+
+  /** Py3 syntax for enumerations. {@link Py3EnumSymbolSyntax}. */
+  public class Py3EnumSyntax  implements Py3TypeSyntax {
+    private final EnumTemplateSpec _template;
+    private final EnumDataSchema _dataSchema;
+    private final Py3NamedTypeSyntax _namedTypeSyntax;
+
+    public Py3EnumSyntax(EnumTemplateSpec _template) {
+      this._template = _template;
+      this._dataSchema = _template.getSchema();
+      this._namedTypeSyntax = new Py3NamedTypeSyntax(_dataSchema);
+    }
+
+    public String typeName() {
+      return _namedTypeSyntax.typeName();
+    }
+
+    @Override
+    public String constructor() {
+      return this.typeName() + ".from_data";
+    }
+
+    public String docString() {
+      return _namedTypeSyntax.docString();
+    }
+
+    public String avroSchemaJson() {
+      return _toAvroSchemaJsonSafe(this._dataSchema);
+    }
+    /**
+     * Returns true in the usual case that we need a module with the same name as this type in which to house
+     * the enum's constants.
+     **/
+    public boolean requiresCompanionModule() {
+      return this.symbols().size() > 0;
+    }
+
+    /**
+     * Creates the string literal union for this enum.
+     *
+     * e.g. for Fruits { APPLE, ORANGE } it will produce the following valid typescript:
+     *
+     * "APPLE" | "ORANGE"
+     **/
+    public String stringLiteralUnion() {
+      List<Py3EnumSymbolSyntax> symbols = this.symbols();
+      if (symbols.size() == 0) {
+        return "void"; // Helps us compile if some bozo declared an empty union.
+      } else {
+        return this._interleaveSymbolStrings(" | ");
+      }
+    }
+
+    /**
+     * Creates the typescript array literal for all values of this enum.
+     * e.g. for Fruits { APPLE, ORANGE } it will produce the following valid python:
+     *
+     * ["APPLE", "ORANGE"]
+     */
+    public String arrayLiteral() {
+      return "[" + this._interleaveSymbolStrings(", ") + "]";
+    }
+
+    @Override
+    public Set<Py3Import> modulesRequiredToUse() {
+      // Since this sucker is declared in its own file you've gotta import it to use it.
+      return _namedTypeSyntax.modulesRequiredToUse();
+    }
+
+    /** Syntax for all the values in this enum */
+    public List<Py3EnumSymbolSyntax> symbols() {
+      List<Py3EnumSymbolSyntax> symbols = new ArrayList<>();
+      for (String symbol : _dataSchema.getSymbols()) {
+        symbols.add(new Py3EnumSymbolSyntax(_template, _dataSchema, symbol));
+      }
+      return symbols;
+    }
+
+    private String _interleaveSymbolStrings(String delimiter) {
+      List<Py3EnumSymbolSyntax> symbols = this.symbols();
+
+      StringBuilder sb = new StringBuilder();
+      for (int i = 0; i < symbols.size(); i++) {
+        Py3EnumSymbolSyntax symbol = symbols.get(i);
+        boolean isLast = (i + 1 == symbols.size());
+        sb.append(symbol.stringLiteralValue());
+
+        if (!isLast) {
+          sb.append(delimiter);
+        }
+      }
+      return sb.toString();
+    }
+  }
+}

--- a/python3/generator/src/main/java/org/coursera/courier/py3/Py3Syntax.java
+++ b/python3/generator/src/main/java/org/coursera/courier/py3/Py3Syntax.java
@@ -20,14 +20,8 @@ import com.linkedin.data.DataList;
 import com.linkedin.data.DataMap;
 import com.linkedin.data.avro.SchemaTranslator;
 import com.linkedin.data.codec.JacksonDataCodec;
-import com.linkedin.data.schema.DataSchema;
+import com.linkedin.data.schema.*;
 import com.linkedin.data.schema.DataSchema.Type;
-import com.linkedin.data.schema.EnumDataSchema;
-import com.linkedin.data.schema.NamedDataSchema;
-import com.linkedin.data.schema.PrimitiveDataSchema;
-import com.linkedin.data.schema.RecordDataSchema;
-import com.linkedin.data.schema.TyperefDataSchema;
-import com.linkedin.data.schema.UnionDataSchema;
 import com.linkedin.data.template.DataTemplateUtil;
 import com.linkedin.pegasus.generator.spec.*;
 import org.coursera.courier.api.ClassTemplateSpecs;
@@ -243,6 +237,17 @@ public class Py3Syntax {
   private String _toAvroSchemaJsonSafe(DataSchema dataSchema) {
     try {
       return _tripleQuote(SchemaTranslator.dataToAvroSchemaJson(dataSchema));
+    } catch (Exception e) {
+      e.printStackTrace();
+      return "\"\"";
+    }
+  }
+
+  private String _toCourierSchemaJsonSafe(DataSchema dataSchema) {
+    try {
+      return SchemaToJsonEncoder
+              .schemaToJson(dataSchema, JsonBuilder.Pretty.COMPACT)
+              .replaceAll("\\\"", "\\\\\"");
     } catch (Exception e) {
       e.printStackTrace();
       return "\"\"";
@@ -707,6 +712,10 @@ public class Py3Syntax {
       return _toAvroSchemaJsonSafe(this._schema);
     }
 
+    public String courierSchemaJson() {
+      return _toCourierSchemaJsonSafe(this._schema);
+    }
+
     /** Return the whole python import block for the file in which this union is declared. */
     public String imports() {
       Set<Py3Import> allImports = new HashSet<>();
@@ -971,6 +980,10 @@ public class Py3Syntax {
       return _toAvroSchemaJsonSafe(this._schema);
     }
 
+    public String courierSchemaJson() {
+      return _toCourierSchemaJsonSafe(this._schema);
+    }
+
     @Override
     public Set<Py3Import> modulesRequiredToUse() {
       return _namedTypeSyntax.modulesRequiredToUse();
@@ -1140,6 +1153,10 @@ public class Py3Syntax {
 
     public String avroSchemaJson() {
       return _toAvroSchemaJsonSafe(this._dataSchema);
+    }
+
+    public String courierSchemaJson() {
+      return _toCourierSchemaJsonSafe(this._dataSchema);
     }
     /**
      * Returns true in the usual case that we need a module with the same name as this type in which to house

--- a/python3/generator/src/main/java/org/coursera/courier/py3/Py3Syntax.java
+++ b/python3/generator/src/main/java/org/coursera/courier/py3/Py3Syntax.java
@@ -886,17 +886,6 @@ public class Py3Syntax {
       return _fieldTypeSyntax().modulesRequiredToUse();
     }
 
-    /**
-     * Just returns a "?" if this was an optional field either due to being decalred optional, or opting not to pass
-     * the STRICT directive into the generator.
-     **/
-    public String questionMarkIfOptional() {
-      boolean isFieldOptional = _schemaField().getOptional();
-      boolean markFieldAsOptional = isFieldOptional || Py3Properties.optionality == org.coursera.courier.py3.Py3Properties.Optionality.REQUIRED_FIELDS_MAY_BE_ABSENT;
-
-      return markFieldAsOptional? "?": "";
-    }
-
     //
     // Private members
     //

--- a/python3/generator/src/main/java/org/coursera/courier/py3/Py3Syntax.java
+++ b/python3/generator/src/main/java/org/coursera/courier/py3/Py3Syntax.java
@@ -893,6 +893,10 @@ public class Py3Syntax {
       return constructorQualifiedByEnclosingClass(this._fieldSyntax());
     }
 
+    public String constructorDefault() {
+      return _schemaField().getOptional()? "courier.OPTIONAL": "courier.REQUIRED";
+    }
+
     public String docString() {
       return docComment(
           _schemaField().getDoc(),

--- a/python3/generator/src/main/java/org/coursera/courier/py3/Py3Syntax.java
+++ b/python3/generator/src/main/java/org/coursera/courier/py3/Py3Syntax.java
@@ -604,26 +604,6 @@ public class Py3Syntax {
     }
 
     /**
-     * Returns the symbol used to access this union member's index in the union's "unpack" return object.
-     *
-     * For example, given union[FortuneCookie], the return object from "unpack" would be { fortuneCookie: union["namespace.FortuneCookie"] as FortuneCookie }
-     */
-    public String unpackString() {
-      DataSchema schema = _memberSchema();
-      String unpackNameBase;
-      if (schema instanceof PrimitiveDataSchema) {
-        unpackNameBase = schema.getUnionMemberKey();
-      } else {
-        unpackNameBase = _memberTypeSyntax().typeName();
-      }
-
-      String punctuationEscaped = unpackNameBase.replaceAll("[\\p{Punct}\\p{Space}]", "");
-      String lowerCased = Character.toLowerCase(punctuationEscaped.charAt(0)) + punctuationEscaped.substring(1);
-
-      return escapeKeyword(lowerCased, EscapeStrategy.MANGLE);
-    }
-
-    /**
      * Returns the union member class name for the given {@link ClassTemplateSpec} as a Typescript
      * source code string.
      *

--- a/python3/generator/src/main/java/org/coursera/courier/py3/Py3Syntax.java
+++ b/python3/generator/src/main/java/org/coursera/courier/py3/Py3Syntax.java
@@ -16,8 +16,10 @@
 
 package org.coursera.courier.py3;
 
+import com.linkedin.data.DataList;
 import com.linkedin.data.DataMap;
 import com.linkedin.data.avro.SchemaTranslator;
+import com.linkedin.data.codec.JacksonDataCodec;
 import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.schema.DataSchema.Type;
 import com.linkedin.data.schema.EnumDataSchema;
@@ -26,9 +28,11 @@ import com.linkedin.data.schema.PrimitiveDataSchema;
 import com.linkedin.data.schema.RecordDataSchema;
 import com.linkedin.data.schema.TyperefDataSchema;
 import com.linkedin.data.schema.UnionDataSchema;
+import com.linkedin.data.template.DataTemplateUtil;
 import com.linkedin.pegasus.generator.spec.*;
 import org.coursera.courier.api.ClassTemplateSpecs;
 
+import java.io.IOException;
 import java.util.*;
 
 /**
@@ -457,13 +461,6 @@ public class Py3Syntax {
     }
   }
 
-  /** Pegasus types that should be rendered as "number" in typescript */
-  private static final Set<Type> Py3_NUMBER_TYPES = new HashSet<>(
-      Arrays.asList(
-          new Type[] { Type.INT, Type.LONG, Type.FLOAT, Type.DOUBLE }
-      )
-  );
-
   /** Pegasus types that should be rendered as "string" in typescript */
   private static final Set<Type> Py3_STRING_TYPES = new HashSet<>(
       Arrays.asList(
@@ -872,6 +869,26 @@ public class Py3Syntax {
 
     public String constructorDefault() {
       return _schemaField().getOptional()? "courier.OPTIONAL": "courier.REQUIRED";
+    }
+
+    public boolean hasDefaultValue() {
+      return _schemaField().getDefault() != null;
+    }
+    public String defaultValue() {
+      if (this.hasDefaultValue()) {
+        Object defaultValue = _schemaField().getDefault();
+        DataList throwawayList = new DataList();
+        throwawayList.add(defaultValue);
+        try {
+          String json = new JacksonDataCodec().listToString(throwawayList);
+          return json.substring(1, json.length() - 1);
+        } catch (IOException e) {
+          e.printStackTrace(System.err);
+          throw new RuntimeException(e);
+        }
+      } else {
+        return "";
+      }
     }
 
     public String docString() {

--- a/python3/generator/src/main/resources/runtime/courier.py
+++ b/python3/generator/src/main/resources/runtime/courier.py
@@ -167,7 +167,18 @@ class Array(MutableSequence):
         return self.data.__len__()
 
     def __getitem__(self, key):
-        return self._construct_item(self.data.__getitem__(key))
+        """Returns either an item or a slice of the Array. For details, see:
+        https://docs.python.org/3/reference/datamodel.html#object.__getitem__
+        Arguments:
+        key -- either an integer (index to the array), or a slice object
+        """
+        item_or_slice = self.data.__getitem__(key)
+        if isinstance(key, slice):
+            # The key was a slice. Return a new Courier Array.
+            return Array(self._item_constructor, data=item_or_slice)
+
+        # The key was an integer. Return an item of the underlying type.
+        return self._construct_item(item_or_slice)
 
     def __setitem__(self, key, item):
         courier_obj = construct_object(item, self._item_constructor)

--- a/python3/generator/src/main/resources/runtime/courier.py
+++ b/python3/generator/src/main/resources/runtime/courier.py
@@ -64,6 +64,17 @@ class ValidationError(Exception):
     def __init__(self, message):
         super(ValidationError, self).__init__(message)
 
+class Record:
+    def __init__(self, data=None):
+        self.data = data if data is not None else {}
+
+    def _set_data_field(self, data_key, type_constructor, new_value):
+        pass
+
+    def _get_data_field(self, data_key, type_constructor):
+        field_data = self.data.get(data_key)
+        return field_data and type_constructor(field_data)
+
 class Array(MutableSequence):
     def __init__(self, courier_index_type, data = []):
         self.data = data
@@ -125,3 +136,7 @@ class Map (MutableMapping):
     #
     def __repr__(self):
         return 'courier.Map(' + repr(self.data) + ')'
+
+REQUIRED = "__COURIER_REQUIRED__"
+OPTIONAL = "__COURIER_OPTIONAL__"
+UNINITIALIZED = "__COURIER_UNINITIALIZED__"

--- a/python3/generator/src/main/resources/runtime/courier.py
+++ b/python3/generator/src/main/resources/runtime/courier.py
@@ -97,6 +97,14 @@ class Record:
         field_data = self.data.get(data_key)
         return field_data and type_constructor(field_data)
 
+class Union:
+    def __init__(self, data=None):
+        self.data = data if data is not None else {}
+
+    def _set_union(self, data_key, new_value):
+        old_data = self.data
+
+
 class Array(MutableSequence):
     def __init__(self, courier_index_type, data = []):
         self.data = data
@@ -126,7 +134,7 @@ class Array(MutableSequence):
     def __repr__(self):
         return 'courier.Array(' + repr(self.data) + ')'
 
-class Map (MutableMapping):
+class Map(MutableMapping):
     def __init__(self, courier_index_type, data = {}):
         self.data = data
         self._construct_item = courier_index_type.from_data if hasattr(courier_index_type, 'from_data') else courier_index_type

--- a/python3/generator/src/main/resources/runtime/courier.py
+++ b/python3/generator/src/main/resources/runtime/courier.py
@@ -19,7 +19,7 @@ import avro.schema
 import json
 from collections.abc import MutableSequence, MutableMapping
 
-def loads(courier_type, json_str):
+def parse(courier_type, json_str):
     json_obj = json.loads(json_str)
     needs_validation = hasattr(courier_type, 'AVRO_SCHEMA') and courier_type.AVRO_SCHEMA is not INVALID_SCHEMA
     if (not needs_validation or avro.io.Validate(courier_type.AVRO_SCHEMA, json_obj)):
@@ -28,7 +28,7 @@ def loads(courier_type, json_str):
     else:
         raise ValidationError("Invalid json string while reading a '%s' type: %s" % (courier_type, json_str))
 
-def dumps(courier_object):
+def serialize(courier_object):
     return json.dumps(data_value(courier_object))
 
 def validate(courier_object):

--- a/python3/generator/src/main/resources/runtime/courier.py
+++ b/python3/generator/src/main/resources/runtime/courier.py
@@ -88,7 +88,8 @@ class Record:
             old_data_value = self.data[data_key]
 
         if new_value in [None, OPTIONAL]:
-            del self.data[data_key]
+            if data_key in self.data:
+                del self.data[data_key]
         else:
             courier_obj = construct_object(new_value, field_type_constructor)
             self.data[data_key] = data_value(courier_obj)
@@ -135,7 +136,7 @@ class Union:
                 new_member_key = member_key
             elif isinstance(new_value, type):
                 new_member_key = member_key
-        if not new_member_key:
+        if new_member_key is None:
             # TODO(py3): better error here
             raise ValueError('Unacceptable value "%s" for union schema %s' % (repr(new_value), str(self.__class__.AVRO_SCHEMA)))
 

--- a/python3/generator/src/main/resources/runtime/courier.py
+++ b/python3/generator/src/main/resources/runtime/courier.py
@@ -82,19 +82,19 @@ class Record:
     def __init__(self, data=None):
         self.data = data if data is not None else {}
 
-    def _set_data_field(self, data_key, new_value, field_type_constructor):
+   def _set_data_field(self, data_key, new_value, field_type_constructor, validate_new_value=True):
         old_data_value = UNINITIALIZED
         if data_key in self.data:
             old_data_value = self.data[data_key]
 
-        if new_value is None:
+        if new_value in [None, OPTIONAL]:
             del self.data[data_key]
         else:
             courier_obj = construct_object(new_value, field_type_constructor)
             self.data[data_key] = data_value(courier_obj)
 
         try:
-            validate(self)
+            validate_new_value and validate(self)
         except ValidationError:
             if old_data_value is not UNINITIALIZED:
                 self.data[data_key] = old_data_value

--- a/python3/generator/src/main/resources/runtime/courier.py
+++ b/python3/generator/src/main/resources/runtime/courier.py
@@ -54,10 +54,6 @@ def data_value(courier_object_or_primitive):
         # Serialize ints and strs directly
         return courier_object_or_primitive
 
-
-
-        return courier_object_or_primitive
-
 def array(courier_type):
     return lambda items: Array(courier_type, items)
 
@@ -116,8 +112,7 @@ class Map (MutableMapping):
         return self.data.__len__()
 
     def __getitem__(self, key):
-        item_data = self.data.__getitem__(key)
-        return item_data and self._construct_item(item_data)
+        return self._construct_item(self.data.__getitem__(key))
 
     def __setitem__(self, key, value):
         return self.data.__setitem__(key, data_value(value))

--- a/python3/generator/src/main/resources/runtime/courier.py
+++ b/python3/generator/src/main/resources/runtime/courier.py
@@ -1,18 +1,26 @@
+# Copyright 2017 Coursera Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+""" The courier runtime.
+
+This file was created and placed here during schema generation, so don't bother
+editing it. If we were doing this right we would distribute it as a package
+through `pip`, and that will probably eventually happen, but until then it gets
+generated right here. Where it's safe.
 """
- Copyright 2016 Coursera Inc.
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-"""
 
 import avro.io
 import avro.schema
@@ -20,6 +28,8 @@ import json
 from collections.abc import MutableSequence, MutableMapping
 
 def parse(courier_type, json_str):
+    if (isinstance(json_str, bytes)):
+        json_str = json_str.decode('utf-8')
     json_obj = json.loads(json_str)
     needs_validation = hasattr(courier_type, 'AVRO_SCHEMA') and courier_type.AVRO_SCHEMA is not INVALID_SCHEMA
     if (not needs_validation or avro.io.Validate(courier_type.AVRO_SCHEMA, json_obj)):
@@ -223,7 +233,7 @@ class Map(MutableMapping):
         return isinstance(other, MutableMapping) and data_value(self) == data_value(other)
 
     #
-    # Private implementaitons
+    # Private implementations
     #
     def _construct_item(self, item):
         item = self._item_constructor(item)

--- a/python3/generator/src/main/resources/runtime/courier.py
+++ b/python3/generator/src/main/resources/runtime/courier.py
@@ -1,0 +1,132 @@
+"""
+ Copyright 2016 Coursera Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import avro.io
+import avro.schema
+import json
+from collections.abc import MutableSequence, MutableMapping
+
+def loads(courier_type, json_str):
+    json_obj = json.loads(json_str)
+    needs_validation = hasattr(courier_type, 'AVRO_SCHEMA')
+    if (not needs_validation or avro.io.Validate(avro.schema.Parse(courier_type.AVRO_SCHEMA), json_obj)):
+        constructor = courier_type.from_data if (hasattr(courier_type, 'from_data')) else courier_type;
+        return constructor(json_obj)
+    else:
+        raise ValidationError("Invalid json string while reading a '%s' type: %s" % (courier_type, json_str))
+
+def dumps(courier_object):
+    return json.dumps(data_value(courier_object))
+
+def validate(courier_object):
+    can_validate = hasattr(courier_object, '__class__') and \
+        hasattr(courier_object.__class__, 'AVRO_SCHEMA')
+    if not can_validate:
+        return
+    else:
+        value = data_value(courier_object)
+        schema = avro.schema.Parse(courier_object.__class__.AVRO_SCHEMA)
+        if not avro.io.Validate(schema, value):
+            raise ValidationError('Validity check failed for %s' % repr(courier_object))
+
+def data_value(courier_object_or_primitive):
+    if (hasattr(courier_object_or_primitive, 'data')):
+        # Serialize the 'data' members of enums, records, and unions
+        return getattr(courier_object_or_primitive, 'data')
+    elif isinstance(courier_object_or_primitive, list):
+        return [data_value(item) for item in courier_object_or_primitive]
+    elif isinstance(courier_object_or_primitive, dict):
+        return {k: data_value(v) for k, v in courier_object_or_primitive.items()}
+    else:
+        # Serialize ints and strs directly
+        return courier_object_or_primitive
+
+
+
+        return courier_object_or_primitive
+
+def array(courier_type):
+    return lambda items: Array(courier_type, items)
+
+def map(courier_type):
+    return lambda items: Map(courier_type, items)
+
+class ValidationError(Exception):
+    def __init__(self, message):
+        super(ValidationError, self).__init__(message)
+
+class Array(MutableSequence):
+    def __init__(self, courier_index_type, data = []):
+        self.data = data
+        self._construct_item = courier_index_type.from_data if hasattr(courier_index_type, 'from_data') else courier_index_type
+
+    #
+    # MutableSequence abstract method implementations
+    #
+    def __len__(self):
+        return self.data.__len__()
+
+    def __getitem__(self, key):
+        return self._construct_item(self.data.__getitem__(key))
+
+    def __setitem__(self, key, item):
+        return self.data.__setitem__(key, data_value(item))
+
+    def __delitem__(self, key):
+        return self.data.__delitem__(key)
+
+    def insert(self, idx, item):
+        return self.data.insert(idx, data_value(item))
+
+    #
+    # Built-in implementations
+    #
+    def __repr__(self):
+        return 'courier.Array(' + repr(self.data) + ')'
+
+class Map (MutableMapping):
+    def __init__(self, courier_index_type, data = {}):
+        self.data = data
+        self._construct_item = courier_index_type.from_data if hasattr(courier_index_type, 'from_data') else courier_index_type
+
+    def items(self):
+        for key in self.data:
+            yield (key, self._construct_item(self.data[key]))
+
+    #
+    # MutableMapping abstract method implementations
+    #
+    def __iter__(self):
+        return self.data.__iter__()
+
+    def __len__(self):
+        return self.data.__len__()
+
+    def __getitem__(self, key):
+        item_data = self.data.__getitem__(key)
+        return item_data and self._construct_item(item_data)
+
+    def __setitem__(self, key, value):
+        return self.data.__setitem__(key, data_value(value))
+
+    def __delitem__(self, key):
+        return self.data.__delitem__(key)
+
+    #
+    # Built-in implementations
+    #
+    def __repr__(self):
+        return 'courier.Map(' + repr(self.data) + ')'

--- a/python3/generator/src/main/resources/runtime/requirements.txt
+++ b/python3/generator/src/main/resources/runtime/requirements.txt
@@ -1,0 +1,4 @@
+### Requirements for using courier python3 bindings at runtime.
+
+# Used for validation
+avro-python3

--- a/python3/generator/src/main/resources/rythm-py3/enum.txt
+++ b/python3/generator/src/main/resources/rythm-py3/enum.txt
@@ -5,6 +5,7 @@
 
 class @enumeration.typeName():
     AVRO_SCHEMA = courier.parse_avro_schema(@enumeration.avroSchemaJson())
+    SCHEMA = courier.parse_schema("""@enumeration.courierSchemaJson()""")
 
     @for(Py3EnumSymbolSyntax symbol : enumeration.symbols()) {
     @symbol.docString()

--- a/python3/generator/src/main/resources/rythm-py3/enum.txt
+++ b/python3/generator/src/main/resources/rythm-py3/enum.txt
@@ -6,22 +6,32 @@
 class @enumeration.typeName():
     AVRO_SCHEMA = courier.parse_avro_schema(@enumeration.avroSchemaJson())
 
-    class Value:
-        def __init__(self, name):
-           self.name = name
-           self.data = name
-
-        def __str__(self):
-          return self.name
-
-        def __repr__(self):
-           return '@(enumeration.typeName()).Value("%s")' % self.name
-@for(Py3EnumSymbolSyntax symbol : enumeration.symbols()) {
+    @for(Py3EnumSymbolSyntax symbol : enumeration.symbols()) {
     @symbol.docString()
-    @symbol.moduleConstValue() = Value(@symbol.stringLiteralValue());
+    @symbol.moduleConstValue() = courier.UNINITIALIZED
+    }
 
-}
-    ALL = [@for(Py3EnumSymbolSyntax symbol : enumeration.symbols()) { @symbol.moduleConstValue(), }]
+    ALL = courier.UNINITIALIZED
+    __BY_NAME = courier.UNINITIALIZED
+
+    def __init__(self, name):
+       self.name = name
+       self.data = name
+
+    def __str__(self):
+      return self.name
+
+    def __repr__(self):
+       return '@(enumeration.typeName())("%s")' % self.name
+
+    @@classmethod
+    def __init_statics__(cls):
+        if cls.ALL is courier.UNINITIALIZED:
+            @for(Py3EnumSymbolSyntax symbol : enumeration.symbols()) {
+            cls.@(symbol.moduleConstValue()) = cls(@symbol.stringLiteralValue());
+            }
+            cls.ALL = [@for(Py3EnumSymbolSyntax symbol : enumeration.symbols()) { cls.@(symbol.moduleConstValue()), }]
+            cls.__BY_NAME = dict([(symbol.name, symbol) for symbol in cls.ALL])
 
     @@classmethod
     def find_by_name(cls, name):
@@ -37,4 +47,4 @@ class @enumeration.typeName():
     def from_data(cls, data):
         return cls.find_by_name(data)
 
-    __BY_NAME = dict([(symbol.name, symbol) for symbol in ALL])
+@(enumeration.typeName()).__init_statics__()

--- a/python3/generator/src/main/resources/rythm-py3/enum.txt
+++ b/python3/generator/src/main/resources/rythm-py3/enum.txt
@@ -1,8 +1,10 @@
 @args org.coursera.courier.py3.Py3Syntax.Py3EnumSyntax enumeration
 @import org.coursera.courier.py3.Py3Syntax.Py3EnumSymbolSyntax
 
+@enumeration.imports()
+
 class @enumeration.typeName():
-    AVRO_SCHEMA = @enumeration.avroSchemaJson()
+    AVRO_SCHEMA = courier.parse_avro_schema(@enumeration.avroSchemaJson())
 
     class Value:
         def __init__(self, name):

--- a/python3/generator/src/main/resources/rythm-py3/enum.txt
+++ b/python3/generator/src/main/resources/rythm-py3/enum.txt
@@ -1,0 +1,38 @@
+@args org.coursera.courier.py3.Py3Syntax.Py3EnumSyntax enumeration
+@import org.coursera.courier.py3.Py3Syntax.Py3EnumSymbolSyntax
+
+class @enumeration.typeName():
+    AVRO_SCHEMA = @enumeration.avroSchemaJson()
+
+    class Value:
+        def __init__(self, name):
+           self.name = name
+           self.data = name
+
+        def __str__(self):
+          return self.name
+
+        def __repr__(self):
+           return '@(enumeration.typeName()).Value("%s")' % self.name
+@for(Py3EnumSymbolSyntax symbol : enumeration.symbols()) {
+    @symbol.docString()
+    @symbol.moduleConstValue() = Value(@symbol.stringLiteralValue());
+
+}
+    ALL = [@for(Py3EnumSymbolSyntax symbol : enumeration.symbols()) { @symbol.moduleConstValue(), }]
+
+    @@classmethod
+    def find_by_name(cls, name):
+        try:
+            return cls.__BY_NAME[name]
+        except KeyError:
+            raise KeyError('"%s" is invalid value for courier enum "@enumeration.typeName()". Valid values are: %s' % (
+              name,
+              [value.name for value in @(enumeration.typeName()).ALL]
+            ))
+
+    @@classmethod
+    def from_data(cls, data):
+        return cls.find_by_name(data)
+
+    __BY_NAME = dict([(symbol.name, symbol) for symbol in ALL])

--- a/python3/generator/src/main/resources/rythm-py3/fixed.txt
+++ b/python3/generator/src/main/resources/rythm-py3/fixed.txt
@@ -1,0 +1,4 @@
+@args org.coursera.courier.py3.Py3Syntax.Py3FixedSyntax fixed
+
+@fixed.docString()
+@fixed.typeName() = str;

--- a/python3/generator/src/main/resources/rythm-py3/record.txt
+++ b/python3/generator/src/main/resources/rythm-py3/record.txt
@@ -6,7 +6,7 @@
 class @(record.typeName())(courier.Record):
     AVRO_SCHEMA = courier.parse_avro_schema(@record.avroSchemaJson())
 
-    def __init__(self, data=None, @for(Py3RecordFieldSyntax field: record.fields()) {@field.accessorName()=@field.constructorDefault(), }):
+    def __init__(self, @for(Py3RecordFieldSyntax field: record.fields()) {@field.accessorName()=@field.constructorDefault(), }data=None):
         super(self.__class__, self).__init__(data)
         @if(!record.fields().isEmpty()){        if data is None:}
             @for(Py3RecordFieldSyntax field: record.fields()) {
@@ -17,6 +17,10 @@ class @(record.typeName())(courier.Record):
             }
 
         courier.validate(self)
+
+    @@classmethod
+    def from_data(cls, data):
+      return cls(data=data)
 
     def __str__(self):
       return '@(record.typeName())(' + \

--- a/python3/generator/src/main/resources/rythm-py3/record.txt
+++ b/python3/generator/src/main/resources/rythm-py3/record.txt
@@ -7,7 +7,7 @@ class @(record.typeName())(courier.Record):
     AVRO_SCHEMA = courier.parse_avro_schema(@record.avroSchemaJson())
 
     def __init__(self, data=None, @for(Py3RecordFieldSyntax field: record.fields()) {@field.accessorName()=@field.constructorDefault(), }):
-        super(@record.typeName(), self).__init__(data)
+        super(self.__class__, self).__init__(data)
         @if(!record.fields().isEmpty()){        if data is None:}
             @for(Py3RecordFieldSyntax field: record.fields()) {
             if @field.accessorName() is courier.REQUIRED:

--- a/python3/generator/src/main/resources/rythm-py3/record.txt
+++ b/python3/generator/src/main/resources/rythm-py3/record.txt
@@ -24,7 +24,6 @@ class @(record.typeName())(courier.Record):
                 self._set_data_field('@field.jsonKey()', @field.accessorName(), @field.constructor(), validate_new_value=False)
             }
 
-        if data is None:
             courier.validate(self)
 
     @@classmethod

--- a/python3/generator/src/main/resources/rythm-py3/record.txt
+++ b/python3/generator/src/main/resources/rythm-py3/record.txt
@@ -13,7 +13,9 @@ class @(record.typeName())(courier.Record):
             if @field.accessorName() is courier.REQUIRED:
                 raise TypeError('__init__() missing required keyword argument: \'@field.accessorName()\'')
             elif @field.accessorName() not in [None, courier.OPTIONAL]:
-                self.data['@field.jsonKey()'] = courier.data_value(@field.accessorName())
+                @field.accessorName()_courier_obj = courier.construct_object(@field.accessorName(), @field.constructor())
+                @field.accessorName()_field_data = courier.data_value(@field.accessorName()_courier_obj)
+                self.data['@field.jsonKey()'] = @field.accessorName()_field_data
             }
 
         courier.validate(self)
@@ -43,11 +45,11 @@ class @(record.typeName())(courier.Record):
     @{ String setter = field.accessorName() + ".setter" }
     @@property
     def @field.accessorName() (self):
-        return self._get_data_field(data_key='@field.jsonKey()', type_constructor=@field.constructor())
+        return self._get_data_field('@field.jsonKey()', @field.constructor())
 
     @@@setter
     def @field.accessorName() (self, new_value):
-        return self._set_data_field('@field.jsonKey()', new_value)
+        return self._set_data_field('@field.jsonKey()', new_value, @field.constructor())
 }@if(record.requiresCompanionModule()) { @for(Py3UnionSyntax union: record.enclosedUnions()) {
      @union(union, 1)
   }

--- a/python3/generator/src/main/resources/rythm-py3/record.txt
+++ b/python3/generator/src/main/resources/rythm-py3/record.txt
@@ -11,7 +11,7 @@ class @(record.typeName())(courier.Record):
         @if(!record.fields().isEmpty()){        if data is None:}
             @for(Py3RecordFieldSyntax field: record.fields()) {
             if @field.accessorName() is courier.REQUIRED:
-                raise courier.ValidationError('"@field.accessorName()" is required to create a "@record.typeName()", but was not provided')
+                raise TypeError('__init__() missing required keyword argument: \'@field.accessorName()\'')
             elif @field.accessorName() not in [None, courier.OPTIONAL]:
                 self.data['@field.jsonKey()'] = courier.data_value(@field.accessorName())
             }

--- a/python3/generator/src/main/resources/rythm-py3/record.txt
+++ b/python3/generator/src/main/resources/rythm-py3/record.txt
@@ -24,7 +24,8 @@ class @(record.typeName())(courier.Record):
                 self._set_data_field('@field.jsonKey()', @field.accessorName(), @field.constructor(), validate_new_value=False)
             }
 
-        courier.validate(self)
+        if data is None:
+            courier.validate(self)
 
     @@classmethod
     def from_data(cls, data):

--- a/python3/generator/src/main/resources/rythm-py3/record.txt
+++ b/python3/generator/src/main/resources/rythm-py3/record.txt
@@ -1,0 +1,58 @@
+@args org.coursera.courier.py3.Py3Syntax.Py3RecordSyntax record
+@import org.coursera.courier.py3.Py3Syntax.Py3UnionSyntax
+@import org.coursera.courier.py3.Py3Syntax.Py3RecordFieldSyntax
+@record.imports()
+class @record.typeName():
+    AVRO_SCHEMA = @record.avroSchemaJson()
+
+    def __init__(self, data=None):
+        self.data = data or {}
+
+    @@classmethod
+    def create(cls, @for(Py3RecordFieldSyntax field: record.fields()) {@field.accessorName(), }):
+        """ Create a @record.typeName() from its fields.
+
+        @for(Py3RecordFieldSyntax field: record.fields()) {
+        @@param @field.accessorName() - @field.typeName()
+        }
+        """
+        record = cls(data={})
+        @for(Py3RecordFieldSyntax field: record.fields()) {
+        record.@field.accessorName() = @field.accessorName()
+        }
+        return record
+
+    def __str__(self):
+      return '@(record.typeName())(' + \
+        @for(Py3RecordFieldSyntax field: record.fields()) {
+          '@(field.accessorName())=' + str(self.@(field.accessorName())) + \
+        }
+      ')'
+
+    def __repr__(self):
+      return '@(record.typeName())(' + repr(self.data) + ')';
+
+    def __eq__(self, other):
+      return isinstance(other, @(record.typeName())) and self.data == other.data
+
+@for(Py3RecordFieldSyntax field: record.fields()) {
+    #
+    # '@field.accessorName()' property
+    #
+    @{ String setter = field.accessorName() + ".setter" }
+    @@property
+    def @field.accessorName() (self):
+        @field.docString()
+        field_data = self.data.get('@field.jsonKey()')
+        field_constructor = @(field.constructor())
+        return field_data and field_constructor(field_data)
+
+
+    @@@setter
+    def @field.accessorName() (self, value):
+        @field.docString()
+        self.data['@field.jsonKey()'] = courier.data_value(value)
+}@if(record.requiresCompanionModule()) { @for(Py3UnionSyntax union: record.enclosedUnions()) {
+     @union(union, 1)
+  }
+}

--- a/python3/generator/src/main/resources/rythm-py3/record.txt
+++ b/python3/generator/src/main/resources/rythm-py3/record.txt
@@ -2,25 +2,21 @@
 @import org.coursera.courier.py3.Py3Syntax.Py3UnionSyntax
 @import org.coursera.courier.py3.Py3Syntax.Py3RecordFieldSyntax
 @record.imports()
-class @record.typeName():
+
+class @(record.typeName())(courier.Record):
     AVRO_SCHEMA = @record.avroSchemaJson()
 
-    def __init__(self, data=None):
-        self.data = data or {}
+    def __init__(self, data=None, @for(Py3RecordFieldSyntax field: record.fields()) {@field.accessorName()=@field.constructorDefault(), }):
+        super(@record.typeName(), self).__init__(data)
+        @if(!record.fields().isEmpty()){        if data is None:}
+            @for(Py3RecordFieldSyntax field: record.fields()) {
+            if @field.accessorName() is courier.REQUIRED:
+                raise courier.ValidationError('"@field.accessorName()" is required to create a "@record.typeName()", but was not provided')
+            elif @field.accessorName() not in [None, courier.OPTIONAL]:
+                self.data['@field.jsonKey()'] = courier.data_value(@field.accessorName())
+            }
 
-    @@classmethod
-    def create(cls, @for(Py3RecordFieldSyntax field: record.fields()) {@field.accessorName(), }):
-        """ Create a @record.typeName() from its fields.
-
-        @for(Py3RecordFieldSyntax field: record.fields()) {
-        @@param @field.accessorName() - @field.typeName()
-        }
-        """
-        record = cls(data={})
-        @for(Py3RecordFieldSyntax field: record.fields()) {
-        record.@field.accessorName() = @field.accessorName()
-        }
-        return record
+        courier.validate(self)
 
     def __str__(self):
       return '@(record.typeName())(' + \
@@ -43,16 +39,30 @@ class @record.typeName():
     @{ String setter = field.accessorName() + ".setter" }
     @@property
     def @field.accessorName() (self):
-        @field.docString()
-        field_data = self.data.get('@field.jsonKey()')
-        field_constructor = @(field.constructor())
-        return field_data and field_constructor(field_data)
-
+        return self._get_data_field(
+            data_key='@field.jsonKey()',
+            type_constructor=@field.constructor()
+        )
 
     @@@setter
-    def @field.accessorName() (self, value):
+    def @field.accessorName() (self, new_value):
         @field.docString()
-        self.data['@field.jsonKey()'] = courier.data_value(value)
+        data_key = '@field.jsonKey()'
+        old_data_value = courier.UNINITIALIZED
+        if data_key in self.data:
+            old_data_value = self.data[data_key]
+
+        if new_value is None:
+            del self.data[data_key]
+        else:
+            self.data[data_key] = courier.data_value(new_value)
+
+        try:
+            courier.validate(self)
+        except courier.ValidationError:
+            if old_data_value is not courier.UNINITIALIZED:
+                self.data[data_key] = old_data_value
+            raise courier.ValidationError('%s is not a valid value for @(record.typeName()).@field.accessorName()' % new_value)
 }@if(record.requiresCompanionModule()) { @for(Py3UnionSyntax union: record.enclosedUnions()) {
      @union(union, 1)
   }

--- a/python3/generator/src/main/resources/rythm-py3/record.txt
+++ b/python3/generator/src/main/resources/rythm-py3/record.txt
@@ -23,8 +23,9 @@ class @(record.typeName())(courier.Record):
             else:
                 self._set_data_field('@field.jsonKey()', @field.accessorName(), @field.constructor(), validate_new_value=False)
             }
-
-            courier.validate(self)
+            @// validate only if the object was created from fields -- if its being created from data then validate can
+            @// be directly called by courier.parse.
+            @if(!record.fields().isEmpty()){            courier.validate(self)}
 
     @@classmethod
     def from_data(cls, data):

--- a/python3/generator/src/main/resources/rythm-py3/record.txt
+++ b/python3/generator/src/main/resources/rythm-py3/record.txt
@@ -6,6 +6,7 @@ import json
 
 class @(record.typeName())(courier.Record):
     AVRO_SCHEMA = courier.parse_avro_schema(@record.avroSchemaJson())
+    SCHEMA = courier.parse_schema("""@record.courierSchemaJson()""")
 
     def __init__(self, @for(Py3RecordFieldSyntax field: record.fields()) {@field.accessorName()=@field.constructorDefault(), }data=None):
         super(self.__class__, self).__init__(data)

--- a/python3/generator/src/main/resources/rythm-py3/record.txt
+++ b/python3/generator/src/main/resources/rythm-py3/record.txt
@@ -4,7 +4,7 @@
 @record.imports()
 
 class @(record.typeName())(courier.Record):
-    AVRO_SCHEMA = @record.avroSchemaJson()
+    AVRO_SCHEMA = courier.parse_avro_schema(@record.avroSchemaJson())
 
     def __init__(self, data=None, @for(Py3RecordFieldSyntax field: record.fields()) {@field.accessorName()=@field.constructorDefault(), }):
         super(@record.typeName(), self).__init__(data)
@@ -39,30 +39,11 @@ class @(record.typeName())(courier.Record):
     @{ String setter = field.accessorName() + ".setter" }
     @@property
     def @field.accessorName() (self):
-        return self._get_data_field(
-            data_key='@field.jsonKey()',
-            type_constructor=@field.constructor()
-        )
+        return self._get_data_field(data_key='@field.jsonKey()', type_constructor=@field.constructor())
 
     @@@setter
     def @field.accessorName() (self, new_value):
-        @field.docString()
-        data_key = '@field.jsonKey()'
-        old_data_value = courier.UNINITIALIZED
-        if data_key in self.data:
-            old_data_value = self.data[data_key]
-
-        if new_value is None:
-            del self.data[data_key]
-        else:
-            self.data[data_key] = courier.data_value(new_value)
-
-        try:
-            courier.validate(self)
-        except courier.ValidationError:
-            if old_data_value is not courier.UNINITIALIZED:
-                self.data[data_key] = old_data_value
-            raise courier.ValidationError('%s is not a valid value for @(record.typeName()).@field.accessorName()' % new_value)
+        return self._set_data_field('@field.jsonKey()', new_value)
 }@if(record.requiresCompanionModule()) { @for(Py3UnionSyntax union: record.enclosedUnions()) {
      @union(union, 1)
   }

--- a/python3/generator/src/main/resources/rythm-py3/record.txt
+++ b/python3/generator/src/main/resources/rythm-py3/record.txt
@@ -36,6 +36,7 @@ class @record.typeName():
       return isinstance(other, @(record.typeName())) and self.data == other.data
 
 @for(Py3RecordFieldSyntax field: record.fields()) {
+
     #
     # '@field.accessorName()' property
     #

--- a/python3/generator/src/main/resources/rythm-py3/record.txt
+++ b/python3/generator/src/main/resources/rythm-py3/record.txt
@@ -11,11 +11,9 @@ class @(record.typeName())(courier.Record):
         @if(!record.fields().isEmpty()){        if data is None:}
             @for(Py3RecordFieldSyntax field: record.fields()) {
             if @field.accessorName() is courier.REQUIRED:
-                raise TypeError('__init__() missing required keyword argument: \'@field.accessorName()\'')
-            elif @field.accessorName() not in [None, courier.OPTIONAL]:
-                @field.accessorName()_courier_obj = courier.construct_object(@field.accessorName(), @field.constructor())
-                @field.accessorName()_field_data = courier.data_value(@field.accessorName()_courier_obj)
-                self.data['@field.jsonKey()'] = @field.accessorName()_field_data
+                raise TypeError('__init__() missing required argument: \'@field.accessorName()\'')
+            else:
+                self._set_data_field('@field.jsonKey()', @field.accessorName(), @field.constructor(), validate_new_value=False)
             }
 
         courier.validate(self)

--- a/python3/generator/src/main/resources/rythm-py3/record.txt
+++ b/python3/generator/src/main/resources/rythm-py3/record.txt
@@ -11,6 +11,12 @@ class @(record.typeName())(courier.Record):
         super(self.__class__, self).__init__(data)
         @if(!record.fields().isEmpty()){        if data is None:}
             @for(Py3RecordFieldSyntax field: record.fields()) {
+            @if(field.hasDefaultValue()) {
+
+            @// TODO(py3): Clean up this godawful way of doing default args
+            if @field.accessorName() in [courier.REQUIRED, courier.OPTIONAL]:
+                @(field.accessorName()) = courier.parse(@field.constructor(), """ @field.defaultValue() """)
+            }
             if @field.accessorName() is courier.REQUIRED:
                 raise TypeError('__init__() missing required argument: \'@field.accessorName()\'')
             else:

--- a/python3/generator/src/main/resources/rythm-py3/record.txt
+++ b/python3/generator/src/main/resources/rythm-py3/record.txt
@@ -2,6 +2,7 @@
 @import org.coursera.courier.py3.Py3Syntax.Py3UnionSyntax
 @import org.coursera.courier.py3.Py3Syntax.Py3RecordFieldSyntax
 @record.imports()
+import json
 
 class @(record.typeName())(courier.Record):
     AVRO_SCHEMA = courier.parse_avro_schema(@record.avroSchemaJson())

--- a/python3/generator/src/main/resources/rythm-py3/typeref.txt
+++ b/python3/generator/src/main/resources/rythm-py3/typeref.txt
@@ -1,0 +1,6 @@
+@args org.coursera.courier.py3.Py3Syntax.Py3TyperefSyntax typeref
+
+@typeref.imports()
+
+@typeref.docString()
+@typeref.typeName() = @typeref.refTypeConstructor()

--- a/python3/generator/src/main/resources/rythm-py3/union.txt
+++ b/python3/generator/src/main/resources/rythm-py3/union.txt
@@ -11,6 +11,13 @@
 @indent()class @(union.typeName())(courier.Union):
 @indent()    AVRO_SCHEMA = courier.parse_avro_schema(@union.avroSchemaJson());
 @indent()
+@indent()    _MEMBERS_BY_KEY = {
+             @for(Py3UnionMemberSyntax member: union.members()) {
+
+@indent()        '@member.unionMemberKey()': {'type': @member.typeName(), 'constructor': @member.constructor() },
+@indent()    }
+
+@indent()    }
 @indent()    #TODO(py3): Put all possible members and constructors here, rather than doing your giant if statements in the __init__
 @indent()    def __init__(self, value=courier.REQUIRED, data=None):
 @indent()        """ Create a @union.typeName() from a dict (probably loaded from json).
@@ -26,12 +33,9 @@
 @indent()            new_data = {}
 @indent()            if value is courier.REQUIRED:
 @indent()                raise TypeError('__init__() missing required argument: value')
-          @for(Py3UnionMemberSyntax member: union.members()) {
-
-@indent()            if isinstance(value, @member.typeName()):
-@indent()                new_data={ '@member.unionMemberKey()': courier.data_value(value) }
-@indent()        }
-
+@indent()            for (member_key, type_info) in self.__class__._MEMBERS_BY_KEY.items():
+@indent()                if isinstance(value, type_info['type']):
+@indent()                    new_data = { member_key: courier.data_value(value) }
 @indent()            if not new_data:
 @indent()                # TODO(py3): better error here
 @indent()                raise ValueError('Unacceptable value "%s" for schema %s' % (value, str(self.__class__.AVRO_SCHEMA)))
@@ -46,6 +50,10 @@
 @indent()    def from_data(cls, data):
 @indent()        return cls(data=data)
 @indent()
+@indent()    @@property
+@indent()    def value(self):
+@indent()       for (key, value) in self.data.items():
+@indent()           return self.__class__._MEMBERS_BY_KEY[key]['constructor'](value)
             @for(Py3UnionMemberSyntax member: union.members()) {
 @indent()
 @indent()    #

--- a/python3/generator/src/main/resources/rythm-py3/union.txt
+++ b/python3/generator/src/main/resources/rythm-py3/union.txt
@@ -11,9 +11,8 @@
 @indent()class @(union.typeName())(courier.Union):
 @indent()    AVRO_SCHEMA = courier.parse_avro_schema(@union.avroSchemaJson());
 @indent()
-@indent()    _MEMBERS_BY_KEY = {
+@indent()    _TYPES_BY_KEY = {
              @for(Py3UnionMemberSyntax member: union.members()) {
-
 @indent()        '@member.unionMemberKey()': {'type': @member.typeName(), 'constructor': @member.constructor() },
 @indent()    }
 
@@ -30,19 +29,7 @@
 @indent()        """
 @indent()        super(self.__class__, self).__init__(data)
 @indent()        if data is None:
-@indent()            new_data = {}
-@indent()            if value is courier.REQUIRED:
-@indent()                raise TypeError('__init__() missing required argument: value')
-@indent()            for (member_key, type_info) in self.__class__._MEMBERS_BY_KEY.items():
-@indent()                if isinstance(value, type_info['type']):
-@indent()                    new_data = { member_key: courier.data_value(value) }
-@indent()            if not new_data:
-@indent()                # TODO(py3): better error here
-@indent()                raise ValueError('Unacceptable value "%s" for union schema %s' % (repr(value), str(self.__class__.AVRO_SCHEMA)))
-@indent()            # Edit data mutably because it may belong to a larger data tree of
-@indent()            # some other object
-@indent()            self.data.clear()
-@indent()            self.data.update(new_data)
+@indent()            self._set_from_value(value)
 @indent()
 @indent()        courier.validate(self)
 @indent()
@@ -57,7 +44,7 @@
 @indent()    @@property
 @indent()    def value(self):
 @indent()       for (key, value) in self.data.items():
-@indent()           return self.__class__._MEMBERS_BY_KEY[key]['constructor'](value)
+@indent()           return self.__class__._TYPES_BY_KEY[key]['constructor'](value)
 @indent()
 @indent()    def __repr__(self):
 @indent()        return '@(union.typeName())(' + repr(self.data) + ')';

--- a/python3/generator/src/main/resources/rythm-py3/union.txt
+++ b/python3/generator/src/main/resources/rythm-py3/union.txt
@@ -31,8 +31,6 @@
 @indent()        super(self.__class__, self).__init__(data)
 @indent()        if data is None:
 @indent()            self._set_from_value(value)
-@indent()
-@indent()        if data is None:
 @indent()            courier.validate(self)
 @indent()
 @indent()    @@classmethod

--- a/python3/generator/src/main/resources/rythm-py3/union.txt
+++ b/python3/generator/src/main/resources/rythm-py3/union.txt
@@ -58,22 +58,11 @@
 @indent()    def value(self):
 @indent()       for (key, value) in self.data.items():
 @indent()           return self.__class__._MEMBERS_BY_KEY[key]['constructor'](value)
-            @for(Py3UnionMemberSyntax member: union.members()) {
-@indent()
-@indent()    #
-@indent()    # '@member.typeName()' union member
-@indent()    #
-@indent()    @@property
-@indent()    def @(member.accessorName())(self):
-@indent()        member_data = self.data.get('@member.unionMemberKey()')
-@indent()        return member_data and @(member.constructor())(member_data)
-@indent()
-@indent()}
 @indent()
 @indent()    def __repr__(self):
 @indent()        return '@(union.typeName())(' + repr(self.data) + ')';
 @indent()
 @indent()    def __eq__(self, other):
-@indent()        return isinstance(other, @(union.typeName())) and self.data == other.data
+@indent()        return isinstance(other, self.__class__) and self.data == other.data
 @indent()
 @indent()

--- a/python3/generator/src/main/resources/rythm-py3/union.txt
+++ b/python3/generator/src/main/resources/rythm-py3/union.txt
@@ -11,7 +11,7 @@
 @indent()class @(union.typeName())(courier.Union):
 @indent()    AVRO_SCHEMA = courier.parse_avro_schema(@union.avroSchemaJson());
 @indent()
-@indent()    def __init__(self, data=None, value=courier.REQUIRED):
+@indent()    def __init__(self, value=courier.REQUIRED, data=None):
 @indent()        super(self.__class__, self).__init__(data)
 @indent()        """ Create a @union.typeName() from a dict (probably loaded from json).
 @indent()
@@ -35,6 +35,10 @@
 @indent()                # TODO(py3): better error here
 @indent()                raise ValueError('Unacceptable value "%s" for schema %s' % (value, str(self.__class__.AVRO_SCHEMA)))
 @indent()        courier.validate(self)
+@indent()
+@indent()    @@classmethod
+@indent()    def from_data(cls, data):
+@indent()        return cls(data=data)
 @indent()
             @for(Py3UnionMemberSyntax member: union.members()) {
 @indent()

--- a/python3/generator/src/main/resources/rythm-py3/union.txt
+++ b/python3/generator/src/main/resources/rythm-py3/union.txt
@@ -1,0 +1,51 @@
+@args org.coursera.courier.py3.Py3Syntax.Py3UnionSyntax union, int indentation
+@import org.coursera.courier.py3.Py3Syntax.Py3UnionSyntax
+@import org.coursera.courier.py3.Py3Syntax.Py3UnionMemberSyntax
+
+@{ String singleIndent = "    " }
+
+@macro("indent") {@for(int i = 0; i < indentation; i++) {@singleIndent}}
+
+@union.imports()
+
+@indent()class @union.typeName():
+@indent()    AVRO_SCHEMA = @union.avroSchemaJson();
+@indent()
+@indent()    def __init__(self, data):
+@indent()        """ Create a @union.typeName() from a dict (probably loaded from json).
+@indent()
+@indent()        You probably want to use the `create` method instead.
+@indent()
+@indent()        The dict must have one of these keys: @for(Py3UnionMemberSyntax member: union.members()) {
+@indent()            - '@member.unionMemberKey()'
+@indent()        }
+@indent()        """
+@indent()        self.data = data
+@indent()
+@indent()    @@classmethod
+@indent()    def create(cls, value):
+@indent()        data_value = courier.data_value(value)
+@indent()      @for(Py3UnionMemberSyntax member: union.members()) {        if isinstance(value, @member.typeName()):
+@indent()            return cls(data={ '@member.unionMemberKey()': data_value })
+@indent()     }
+@indent()
+@indent()        raise courier.ValidationError('%s was not a valid option for @(union.typeName())' % value)
+            @for(Py3UnionMemberSyntax member: union.members()) {
+@indent()
+@indent()    #
+@indent()    # '@member.typeName()' union member
+@indent()    #
+@indent()    @@property
+@indent()    def @(member.accessorName())(self):
+@indent()        member_data = self.data.get('@member.unionMemberKey()')
+@indent()        return member_data and @(member.constructor())(member_data)
+@indent()
+@indent()}
+@indent()
+@indent()    def __repr__(self):
+@indent()        return '@(union.typeName())(' + repr(self.data) + ')';
+@indent()
+@indent()    def __eq__(self, other):
+@indent()        return isinstance(other, @(union.typeName())) and self.data == other.data
+@indent()
+@indent()

--- a/python3/generator/src/main/resources/rythm-py3/union.txt
+++ b/python3/generator/src/main/resources/rythm-py3/union.txt
@@ -38,7 +38,7 @@
 @indent()                    new_data = { member_key: courier.data_value(value) }
 @indent()            if not new_data:
 @indent()                # TODO(py3): better error here
-@indent()                raise ValueError('Unacceptable value "%s" for schema %s' % (value, str(self.__class__.AVRO_SCHEMA)))
+@indent()                raise ValueError('Unacceptable value "%s" for union schema %s' % (repr(value), str(self.__class__.AVRO_SCHEMA)))
 @indent()            # Edit data mutably because it may belong to a larger data tree of
 @indent()            # some other object
 @indent()            self.data.clear()
@@ -49,6 +49,10 @@
 @indent()    @@classmethod
 @indent()    def from_data(cls, data):
 @indent()        return cls(data=data)
+@indent()
+@indent()    @@property
+@indent()    def as_value_type(self):
+@indent()        return self.value
 @indent()
 @indent()    @@property
 @indent()    def value(self):

--- a/python3/generator/src/main/resources/rythm-py3/union.txt
+++ b/python3/generator/src/main/resources/rythm-py3/union.txt
@@ -8,10 +8,11 @@
 
 @union.imports()
 
-@indent()class @union.typeName():
+@indent()class @(union.typeName())(courier.Union):
 @indent()    AVRO_SCHEMA = courier.parse_avro_schema(@union.avroSchemaJson());
 @indent()
-@indent()    def __init__(self, data):
+@indent()    def __init__(self, data=None, value=courier.REQUIRED):
+@indent()        super(self.__class__, self).__init__(data)
 @indent()        """ Create a @union.typeName() from a dict (probably loaded from json).
 @indent()
 @indent()        You probably want to use the `create` method instead.
@@ -21,15 +22,20 @@
 @indent()        }
 @indent()        """
 @indent()        self.data = data
+@indent()        if data is None:
+@indent()            if value is courier.REQUIRED:
+@indent()                raise TypeError('__init__() missing required argument: value')
+          @for(Py3UnionMemberSyntax member: union.members()) {
+
+@indent()            if isinstance(value, @member.typeName()):
+@indent()                self.data={ '@member.unionMemberKey()': courier.data_value(value) }
+@indent()        }
+
+@indent()            if value is courier.REQUIRED:
+@indent()                # TODO(py3): better error here
+@indent()                raise ValueError('Unacceptable value "%s" for schema %s' % (value, str(self.__class__.AVRO_SCHEMA)))
+@indent()        courier.validate(self)
 @indent()
-@indent()    @@classmethod
-@indent()    def create(cls, value):
-@indent()        data_value = courier.data_value(value)
-@indent()      @for(Py3UnionMemberSyntax member: union.members()) {        if isinstance(value, @member.typeName()):
-@indent()            return cls(data={ '@member.unionMemberKey()': data_value })
-@indent()     }
-@indent()
-@indent()        raise courier.ValidationError('%s was not a valid option for @(union.typeName())' % value)
             @for(Py3UnionMemberSyntax member: union.members()) {
 @indent()
 @indent()    #

--- a/python3/generator/src/main/resources/rythm-py3/union.txt
+++ b/python3/generator/src/main/resources/rythm-py3/union.txt
@@ -9,7 +9,8 @@
 @union.imports()
 
 @indent()class @(union.typeName())(courier.Union):
-@indent()    AVRO_SCHEMA = courier.parse_avro_schema(@union.avroSchemaJson());
+@indent()    AVRO_SCHEMA = courier.parse_avro_schema(@union.avroSchemaJson())
+@indent()    SCHEMA = courier.parse_schema("""@union.courierSchemaJson()""")
 @indent()
 @indent()    _TYPES_BY_KEY = {
              @for(Py3UnionMemberSyntax member: union.members()) {

--- a/python3/generator/src/main/resources/rythm-py3/union.txt
+++ b/python3/generator/src/main/resources/rythm-py3/union.txt
@@ -11,8 +11,8 @@
 @indent()class @(union.typeName())(courier.Union):
 @indent()    AVRO_SCHEMA = courier.parse_avro_schema(@union.avroSchemaJson());
 @indent()
+@indent()    #TODO(py3): Put all possible members and constructors here, rather than doing your giant if statements in the __init__
 @indent()    def __init__(self, value=courier.REQUIRED, data=None):
-@indent()        super(self.__class__, self).__init__(data)
 @indent()        """ Create a @union.typeName() from a dict (probably loaded from json).
 @indent()
 @indent()        You probably want to use the `create` method instead.
@@ -21,19 +21,25 @@
 @indent()            - '@member.unionMemberKey()'
 @indent()        }
 @indent()        """
-@indent()        self.data = data
+@indent()        super(self.__class__, self).__init__(data)
 @indent()        if data is None:
+@indent()            new_data = {}
 @indent()            if value is courier.REQUIRED:
 @indent()                raise TypeError('__init__() missing required argument: value')
           @for(Py3UnionMemberSyntax member: union.members()) {
 
 @indent()            if isinstance(value, @member.typeName()):
-@indent()                self.data={ '@member.unionMemberKey()': courier.data_value(value) }
+@indent()                new_data={ '@member.unionMemberKey()': courier.data_value(value) }
 @indent()        }
 
-@indent()            if value is courier.REQUIRED:
+@indent()            if not new_data:
 @indent()                # TODO(py3): better error here
 @indent()                raise ValueError('Unacceptable value "%s" for schema %s' % (value, str(self.__class__.AVRO_SCHEMA)))
+@indent()            # Edit data mutably because it may belong to a larger data tree of
+@indent()            # some other object
+@indent()            self.data.clear()
+@indent()            self.data.update(new_data)
+@indent()
 @indent()        courier.validate(self)
 @indent()
 @indent()    @@classmethod

--- a/python3/generator/src/main/resources/rythm-py3/union.txt
+++ b/python3/generator/src/main/resources/rythm-py3/union.txt
@@ -9,7 +9,7 @@
 @union.imports()
 
 @indent()class @union.typeName():
-@indent()    AVRO_SCHEMA = @union.avroSchemaJson();
+@indent()    AVRO_SCHEMA = courier.parse_avro_schema(@union.avroSchemaJson());
 @indent()
 @indent()    def __init__(self, data):
 @indent()        """ Create a @union.typeName() from a dict (probably loaded from json).

--- a/python3/generator/src/main/resources/rythm-py3/union.txt
+++ b/python3/generator/src/main/resources/rythm-py3/union.txt
@@ -19,7 +19,7 @@
 
 @indent()    }
 @indent()    #TODO(py3): Put all possible members and constructors here, rather than doing your giant if statements in the __init__
-@indent()    def __init__(self, value=courier.REQUIRED, data=None):
+@indent()    def __init__(self, value=courier.REQUIRED, data=None, _courier_validate_on_init=False):
 @indent()        """ Create a @union.typeName() from a dict (probably loaded from json).
 @indent()
 @indent()        You probably want to use the `create` method instead.
@@ -32,7 +32,8 @@
 @indent()        if data is None:
 @indent()            self._set_from_value(value)
 @indent()
-@indent()        courier.validate(self)
+@indent()        if data is None:
+@indent()            courier.validate(self)
 @indent()
 @indent()    @@classmethod
 @indent()    def from_data(cls, data):

--- a/python3/generator/src/main/resources/rythm-py3/union.txt
+++ b/python3/generator/src/main/resources/rythm-py3/union.txt
@@ -45,7 +45,9 @@
 @indent()    @@property
 @indent()    def value(self):
 @indent()       for (key, value) in self.data.items():
-@indent()           return self.__class__._TYPES_BY_KEY[key]['constructor'](value)
+@indent()           constructor_type = self.__class__._TYPES_BY_KEY[key]['constructor']
+@indent()           construct = constructor_type.from_data if (hasattr(constructor_type, 'from_data')) else constructor_type
+@indent()           return construct(value)
 @indent()
 @indent()    def __repr__(self):
 @indent()        return '@(union.typeName())(' + repr(self.data) + ')';

--- a/python3/testsuite/.gitignore
+++ b/python3/testsuite/.gitignore
@@ -1,0 +1,4 @@
+src/py3-bindings
+
+py3bindings
+__pycache__

--- a/python3/testsuite/Dockerfile
+++ b/python3/testsuite/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.6
+
+RUN pip install avro-python3
+CMD python3 /app/src/runtests.py
+
+VOLUME /app

--- a/python3/testsuite/full-build.sh
+++ b/python3/testsuite/full-build.sh
@@ -7,4 +7,4 @@ printf 'Building docker image for running python3 test-suite...'
 docker build --tag courier-python3-test . > /dev/null
 printf 'Done\n\n'
 
-docker run -v $script_dir:/app courier-python3-test
+docker run -v --rm $script_dir:/app courier-python3-test

--- a/python3/testsuite/full-build.sh
+++ b/python3/testsuite/full-build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+cd $script_dir
+
+printf 'Building docker image for running python3 test-suite...'
+docker build --tag courier-python3-test . > /dev/null
+printf 'Done\n\n'
+
+docker run -v $script_dir:/app courier-python3-test

--- a/python3/testsuite/full-build.sh
+++ b/python3/testsuite/full-build.sh
@@ -7,4 +7,4 @@ printf 'Building docker image for running python3 test-suite...'
 docker build --tag courier-python3-test . > /dev/null
 printf 'Done\n\n'
 
-docker run -v --rm $script_dir:/app courier-python3-test
+docker run --rm -v $script_dir:/app courier-python3-test

--- a/python3/testsuite/src/runtests.py
+++ b/python3/testsuite/src/runtests.py
@@ -198,6 +198,24 @@ class TestCourierBindings(unittest.TestCase):
         self.assertEqual(eight_ball.answer, MagicEightBallAnswer.ASK_AGAIN_LATER)
         self.assertEqual(courier.serialize(eight_ball), """{"question": "??", "answer": "ASK_AGAIN_LATER"}""")
 
+    def test_record_optional_field(self):
+        no_fields_from_data = courier.parse(WithOptionalPrimitives, '{}')
+        no_fields_from_value = WithOptionalPrimitives()
+        self.assertIsNone(no_fields_from_data.intField)
+        self.assertIsNone(no_fields_from_value.intField)
+        self.assertEqual(no_fields_from_data, no_fields_from_value)
+        self.assertEqual(courier.serialize(no_fields_from_data), '{}')
+
+        int_field_from_data = courier.parse(WithOptionalPrimitives, '{"intField":1}')
+        int_field_from_value = WithOptionalPrimitives(intField=1)
+        self.assertEqual(int_field_from_data.intField, 1)
+        self.assertEqual(int_field_from_value.intField, 1)
+        self.assertEqual(int_field_from_data, int_field_from_value)
+        self.assertEqual(courier.serialize(int_field_from_data), '{"intField": 1}')
+
+        int_field_from_value.intField = None
+        self.assertEqual(courier.serialize(int_field_from_value), '{}')
+
     def test_record_validate_shallow(self):
         eight_ball = self.__make_eight_ball()
         courier.validate(eight_ball) # should be valid immediately after creation

--- a/python3/testsuite/src/runtests.py
+++ b/python3/testsuite/src/runtests.py
@@ -366,10 +366,7 @@ class TestCourierBindings(unittest.TestCase):
 
 
     def __make_eight_ball(self):
-        return MagicEightBall(
-            question='Will I ever love again?',
-            answer=MagicEightBallAnswer.IT_IS_CERTAIN
-        )
+        return MagicEightBall('Will I ever love again?', MagicEightBallAnswer.IT_IS_CERTAIN)
 
 if __name__ == '__main__':
     unittest.main()

--- a/python3/testsuite/src/runtests.py
+++ b/python3/testsuite/src/runtests.py
@@ -399,6 +399,8 @@ class TestCourierBindings(unittest.TestCase):
 
         rec.ints = [100, 101]
         self.assertTrue('"ints": [100, 101]' in courier.serialize(rec))
+        rec.strings = rec.strings[0:1]
+        self.assertTrue('"strings": ["seventeen"]' in courier.serialize(rec))
 
     def test_array_and_map_complex(self):
         custom_ints = [1, 2]

--- a/python3/testsuite/src/runtests.py
+++ b/python3/testsuite/src/runtests.py
@@ -1,4 +1,6 @@
 import py3bindings.courier as courier
+import avro.io
+import avro.schema
 from py3bindings.org.coursera.arrays.WithAnonymousUnionArray import WithAnonymousUnionArray
 from py3bindings.org.coursera.arrays.WithCustomArrayTestId import WithCustomArrayTestId
 from py3bindings.org.coursera.arrays.WithCustomTypesArray import WithCustomTypesArray
@@ -146,26 +148,26 @@ import unittest
 
 
 class TestCourierBindings(unittest.TestCase):
-    def test_enum_find_by_name(self):
+    def _test_enum_find_by_name(self):
         self.assertEqual(MagicEightBallAnswer.find_by_name('IT_IS_CERTAIN'), MagicEightBallAnswer.IT_IS_CERTAIN)
         self.assertRaises(KeyError, lambda: MagicEightBallAnswer.find_by_name('Does not exist'))
 
-    def test_enum_all(self):
+    def _test_enum_all(self):
         self.assertEqual(len(MagicEightBallAnswer.ALL), 3)
         self.assertTrue(MagicEightBallAnswer.IT_IS_CERTAIN in MagicEightBallAnswer.ALL)
         self.assertTrue(MagicEightBallAnswer.ASK_AGAIN_LATER in MagicEightBallAnswer.ALL)
         self.assertTrue(MagicEightBallAnswer.OUTLOOK_NOT_SO_GOOD in MagicEightBallAnswer.ALL)
 
-    def test_enum_from_string(self):
+    def _test_enum_from_string(self):
         good_answer = courier.parse(MagicEightBallAnswer, '"IT_IS_CERTAIN"')
         self.assertEqual(good_answer, MagicEightBallAnswer.IT_IS_CERTAIN)
         self.assertRaises(courier.ValidationError, lambda: courier.parse(MagicEightBallAnswer, '"WELL_THIS_DOESNT_EXIST"'))
 
-    def test_enum_empty(self):
+    def _test_enum_empty(self):
         self.assertEqual(len(EmptyEnum.ALL), 0)
         self.assertRaises(KeyError, lambda: EmptyEnum.find_by_name('ANYTHING'))
 
-    def test_enum_properties(self):
+    def _test_enum_properties(self):
         """ TODO(py3) Not yet implemented in python bindings. This is stuff like:
 
             enum EnumProperties {
@@ -176,7 +178,7 @@ class TestCourierBindings(unittest.TestCase):
         """
         pass
 
-    def test_record_json_dumps_and_loads(self):
+    def _test_record_json_dumps_and_loads(self):
         question = 'Will I ever love again?'
         answer = MagicEightBallAnswer.IT_IS_CERTAIN
         eight_ball = MagicEightBall(question=question, answer=answer)
@@ -188,7 +190,7 @@ class TestCourierBindings(unittest.TestCase):
         self.assertEqual(courier.serialize(eight_ball), expected_json)
         self.assertEqual(reloaded_eight_ball, eight_ball)
 
-    def test_record_set_and_get(self):
+    def _test_record_set_and_get(self):
         question = 'Will I ever love again?'
         answer = MagicEightBallAnswer.IT_IS_CERTAIN
         eight_ball = MagicEightBall(question=question, answer=answer)
@@ -198,7 +200,7 @@ class TestCourierBindings(unittest.TestCase):
         self.assertEqual(eight_ball.answer, MagicEightBallAnswer.ASK_AGAIN_LATER)
         self.assertEqual(courier.serialize(eight_ball), """{"question": "??", "answer": "ASK_AGAIN_LATER"}""")
 
-    def test_record_optional_field(self):
+    def _test_record_optional_field(self):
         no_fields_from_data = courier.parse(WithOptionalPrimitives, '{}')
         no_fields_from_value = WithOptionalPrimitives()
         self.assertIsNone(no_fields_from_data.intField)
@@ -216,7 +218,7 @@ class TestCourierBindings(unittest.TestCase):
         int_field_from_value.intField = None
         self.assertEqual(courier.serialize(int_field_from_value), '{}')
 
-    def test_record_default_primitives(self):
+    def _test_record_default_primitives(self):
         num_defaults = NumericDefaults()
         self.assertEqual(num_defaults.i, 2147483647)
         self.assertEqual(num_defaults.l, 9223372036854775807)
@@ -235,7 +237,7 @@ class TestCourierBindings(unittest.TestCase):
 #            enumWithDefault=Fruits.APPLE
 #        )
 
-    def test_courier_array_can_be_sliced(self):
+    def _test_courier_array_can_be_sliced(self):
         """ There was a bug that caused slicing into an array of courier strings
         to produce a python array instead of another Courier array.
         
@@ -244,7 +246,7 @@ class TestCourierBindings(unittest.TestCase):
         courier_array = courier.Array(str, ['apples'])
         self.assertEqual(courier_array, courier_array[0:1])
 
-    def test_record_validate_shallow(self):
+    def _test_record_validate_shallow(self):
         eight_ball = self.__make_eight_ball()
         courier.validate(eight_ball) # should be valid immediately after creation
 
@@ -268,39 +270,39 @@ class TestCourierBindings(unittest.TestCase):
         self.assertRaises(courier.ValidationError, invalid_8ball_from_data)
         self.assertRaises(TypeError, invalid_8ball_from_construction)
 
-    def test_record_validate_deep(self):
+    def _test_record_validate_deep(self):
         pass
 
-    def test_record_with_typeref_field(self):
+    def _test_record_with_typeref_field(self):
         pass
 
-    def test_record_with_union_field(self):
+    def _test_record_with_union_field(self):
         pass
 
-    def test_record_with_list_field(self):
+    def _test_record_with_list_field(self):
         pass
 
-    def test_with_typed_definition(self):
+    def _test_with_typed_definition(self):
         """ TODO(py3): see reference suite WithFlatTypedDefinition.courier """
         pass
 
-    def test_with_flat_typed_definition(self):
+    def _test_with_flat_typed_definition(self):
         """ TODO(py3): see reference suite WithFlatTypedDefinition.courier """
         pass
 
-    def test_record_without_namespace(self):
+    def _test_record_without_namespace(self):
         record = WithoutNamespace(field1="herp")
         self.assertEqual(courier.parse(WithoutNamespace, courier.serialize(record)), record)
 
-    def test_record_with_reserved_name(self):
+    def _test_record_with_reserved_name(self):
         record = class_(private="herp")
         self.assertEqual(courier.serialize(record), """{"private": "herp"}""")
 
-    def test_with_include(self):
+    def _test_with_include(self):
         """" TODO(py3): see reference suite WithInclude.courier """
         pass
 
-    def test_json_property(self):
+    def _test_json_property(self):
         """" TODO(py3): Implement support for @json property.
 
         But what does it do? It's supposed to work on a record like this:
@@ -313,7 +315,7 @@ class TestCourierBindings(unittest.TestCase):
         """
         pass
 
-    def test_omit(self):
+    def _test_omit(self):
         """" TODO(py3): Implement support for @py3.omit property
 
         For those types that we don't support generation for yet. Looks like:
@@ -326,14 +328,28 @@ class TestCourierBindings(unittest.TestCase):
         """
         pass
 
-    def test_union(self):
+    def _test_union(self):
         union = WithComplexTypesUnion.Union(
           value=py3bindings.org.coursera.records.test.Empty.Empty()
         )
 
         self.assertEqual(union.value, py3bindings.org.coursera.records.test.Empty.Empty())
 
-    def test_union_as_record_field(self):
+    def _test_union_with_fields_that_have_args(self):
+        """ TODO: This bug is not fixed. Fix it """
+        union = WithRecordCustomTypeUnion(Message('Hello, Simon!', 'Blabla'))
+        print('**** ', union)
+
+    def test_record_with_inline_union(self):
+        from py3bindings.org.coursera.records.RecordWithInlineUnion import RecordWithInlineUnion
+
+        # rec = RecordWithInlineUnion(RecordWithInlineUnion.InlineUnion(Note('Hello, Simon!')))
+        data = {'org.coursera.records.Note': { 'text': 'Name' }}
+        un = RecordWithInlineUnion.InlineUnion(data=data)
+        rec = RecordWithInlineUnion(un)
+        print('**** ', rec)
+
+    def _test_union_as_record_field(self):
         # We should be able to set the union by any of its unioned types
         record = WithComplexTypesUnion(union=Fruits.APPLE)
         def assert_json_equal(json):
@@ -361,7 +377,7 @@ class TestCourierBindings(unittest.TestCase):
         record.union = union
         self.assertEqual(record.union, Fruits.APPLE)
 
-    def test_union_of_arrays_and_maps(self):
+    def _test_union_of_arrays_and_maps(self):
         record = WithComplexTypesUnion(union=[Simple('Hello world')])
         self.assertEqual(len(record.union), 1)
         self.assertEqual(record.union, [Simple('Hello world')])
@@ -374,7 +390,7 @@ class TestCourierBindings(unittest.TestCase):
         self.assertEqual(record.union['a'], Simple("a message"))
         self.assertEqual(courier.serialize(record), '{"union": {"map": {"a": {"message": "a message"}}}}')
 
-    def test_array_primitive(self):
+    def _test_array_primitive(self):
         ints = [1,2,3,4]
         longs = [5,6,7,8]
         floats = [9.0,10.0,11.0,12.0]
@@ -402,7 +418,7 @@ class TestCourierBindings(unittest.TestCase):
         rec.strings = rec.strings[0:1]
         self.assertTrue('"strings": ["seventeen"]' in courier.serialize(rec))
 
-    def test_array_and_map_complex(self):
+    def _test_array_and_map_complex(self):
         custom_ints = [1, 2]
         hello = Simple(message="Hello")
         world = Simple(message="world")

--- a/python3/testsuite/src/runtests.py
+++ b/python3/testsuite/src/runtests.py
@@ -1,0 +1,363 @@
+import py3bindings.courier as courier
+from py3bindings.org.coursera.arrays.WithAnonymousUnionArray import WithAnonymousUnionArray
+from py3bindings.org.coursera.arrays.WithCustomArrayTestId import WithCustomArrayTestId
+from py3bindings.org.coursera.arrays.WithCustomTypesArray import WithCustomTypesArray
+from py3bindings.org.coursera.arrays.WithCustomTypesArrayUnion import WithCustomTypesArrayUnion
+from py3bindings.org.coursera.arrays.WithPrimitivesArray import WithPrimitivesArray
+from py3bindings.org.coursera.arrays.WithRecordArray import WithRecordArray
+from py3bindings.org.coursera.customtypes.BooleanId import BooleanId
+from py3bindings.org.coursera.customtypes.BoxedIntId import BoxedIntId
+from py3bindings.org.coursera.customtypes.ByteId import ByteId
+from py3bindings.org.coursera.customtypes.CaseClassCustomIntWrapper import CaseClassCustomIntWrapper
+from py3bindings.org.coursera.customtypes.CaseClassStringIdWrapper import CaseClassStringIdWrapper
+from py3bindings.org.coursera.customtypes.CharId import CharId
+from py3bindings.org.coursera.customtypes.CustomArrayTestId import CustomArrayTestId
+from py3bindings.org.coursera.customtypes.CustomInt import CustomInt
+from py3bindings.org.coursera.customtypes.CustomIntWrapper import CustomIntWrapper
+from py3bindings.org.coursera.customtypes.CustomMapTestKeyId import CustomMapTestKeyId
+from py3bindings.org.coursera.customtypes.CustomMapTestValueId import CustomMapTestValueId
+from py3bindings.org.coursera.customtypes.CustomRecord import CustomRecord
+from py3bindings.org.coursera.customtypes.CustomRecordTestId import CustomRecordTestId
+from py3bindings.org.coursera.customtypes.CustomUnionTestId import CustomUnionTestId
+from py3bindings.org.coursera.customtypes.DateTime import DateTime
+from py3bindings.org.coursera.customtypes.DoubleId import DoubleId
+from py3bindings.org.coursera.customtypes.FloatId import FloatId
+from py3bindings.org.coursera.customtypes.IntId import IntId
+from py3bindings.org.coursera.customtypes.LongId import LongId
+from py3bindings.org.coursera.customtypes.ShortId import ShortId
+from py3bindings.org.coursera.customtypes.StringId import StringId
+from py3bindings.org.coursera.deprecated.DeprecatedRecord import DeprecatedRecord
+from py3bindings.org.coursera.enums.EmptyEnum import EmptyEnum
+from py3bindings.org.coursera.enums.EnumProperties import EnumProperties
+from py3bindings.org.coursera.enums.Fruits import Fruits
+from py3bindings.org.coursera.escaping.class_ import class_
+from py3bindings.org.coursera.escaping.DefaultLiteralEscaping import DefaultLiteralEscaping
+from py3bindings.org.coursera.escaping.KeywordEscaping import KeywordEscaping
+from py3bindings.org.coursera.escaping.ReservedClassFieldEscaping import ReservedClassFieldEscaping
+from py3bindings.org.coursera.fixed.Fixed8 import Fixed8
+from py3bindings.org.coursera.fixed.WithFixed8 import WithFixed8
+from py3bindings.org.coursera.maps.Toggle import Toggle
+from py3bindings.org.coursera.maps.WithComplexTypesMap import WithComplexTypesMap
+from py3bindings.org.coursera.maps.WithComplexTypesMapUnion import WithComplexTypesMapUnion
+from py3bindings.org.coursera.maps.WithCustomMapTestIds import WithCustomMapTestIds
+from py3bindings.org.coursera.maps.WithCustomTypesMap import WithCustomTypesMap
+from py3bindings.org.coursera.maps.WithPrimitivesMap import WithPrimitivesMap
+from py3bindings.org.coursera.maps.WithTypedKeyMap import WithTypedKeyMap
+from py3bindings.org.coursera.records.class_ import class_
+from py3bindings.org.coursera.records.CourierFile import CourierFile
+from py3bindings.org.coursera.records.JsonTest import JsonTest
+from py3bindings.org.coursera.records.Message import Message
+from py3bindings.org.coursera.records.Note import Note
+from py3bindings.org.coursera.records.primitivestyle.Simple import Simple
+from py3bindings.org.coursera.records.primitivestyle.WithComplexTypes import WithComplexTypes
+from py3bindings.org.coursera.records.primitivestyle.WithPrimitives import WithPrimitives
+from py3bindings.org.coursera.records.test.BooleanTyperef import BooleanTyperef
+from py3bindings.org.coursera.records.test.BytesTyperef import BytesTyperef
+from py3bindings.org.coursera.records.test.DoubleTyperef import DoubleTyperef
+from py3bindings.org.coursera.records.test.Empty import Empty
+import py3bindings.org.coursera.records.test.Empty
+from py3bindings.org.coursera.records.test.Empty2 import Empty2
+from py3bindings.org.coursera.records.test.FloatTyperef import FloatTyperef
+from py3bindings.org.coursera.records.test.InlineOptionalRecord import InlineOptionalRecord
+from py3bindings.org.coursera.records.test.InlineRecord import InlineRecord
+from py3bindings.org.coursera.records.test.IntCustomType import IntCustomType
+from py3bindings.org.coursera.records.test.IntTyperef import IntTyperef
+from py3bindings.org.coursera.records.test.LongTyperef import LongTyperef
+from py3bindings.org.coursera.records.test.Message import Message
+from py3bindings.org.coursera.records.test.NumericDefaults import NumericDefaults
+from py3bindings.org.coursera.records.test.OptionalBooleanTyperef import OptionalBooleanTyperef
+from py3bindings.org.coursera.records.test.OptionalBytesTyperef import OptionalBytesTyperef
+from py3bindings.org.coursera.records.test.OptionalDoubleTyperef import OptionalDoubleTyperef
+from py3bindings.org.coursera.records.test.OptionalFloatTyperef import OptionalFloatTyperef
+from py3bindings.org.coursera.records.test.OptionalIntCustomType import OptionalIntCustomType
+from py3bindings.org.coursera.records.test.OptionalIntTyperef import OptionalIntTyperef
+from py3bindings.org.coursera.records.test.OptionalLongTyperef import OptionalLongTyperef
+from py3bindings.org.coursera.records.test.OptionalStringTyperef import OptionalStringTyperef
+from py3bindings.org.coursera.records.test.packaging.Empty import Empty
+# TODO(erem): Fix this from py3bindings.org.coursera.records.test.RecursivelyDefinedRecord import RecursivelyDefinedRecord
+from py3bindings.org.coursera.records.test.Simple import Simple
+from py3bindings.org.coursera.records.test.StringTyperef import StringTyperef
+from py3bindings.org.coursera.records.test.With22Fields import With22Fields
+from py3bindings.org.coursera.records.test.With23Fields import With23Fields
+from py3bindings.org.coursera.records.test.WithCaseClassCustomType import WithCaseClassCustomType
+from py3bindings.org.coursera.records.test.WithComplexTypeDefaults import WithComplexTypeDefaults
+from py3bindings.org.coursera.records.test.WithComplexTyperefs import WithComplexTyperefs
+from py3bindings.org.coursera.records.test.WithComplexTypes import WithComplexTypes
+from py3bindings.org.coursera.records.test.WithCourierFile import WithCourierFile
+from py3bindings.org.coursera.records.test.WithCustomIntWrapper import WithCustomIntWrapper
+from py3bindings.org.coursera.records.test.WithCustomRecord import WithCustomRecord
+from py3bindings.org.coursera.records.test.WithCustomRecordTestId import WithCustomRecordTestId
+from py3bindings.org.coursera.records.test.WithDateTime import WithDateTime
+from py3bindings.org.coursera.records.test.WithInclude import WithInclude
+from py3bindings.org.coursera.records.test.WithInlineRecord import WithInlineRecord
+from py3bindings.org.coursera.records.test.WithOmitField import WithOmitField
+from py3bindings.org.coursera.records.test.WithOptionalComplexTypeDefaults import WithOptionalComplexTypeDefaults
+from py3bindings.org.coursera.records.test.WithOptionalComplexTypes import WithOptionalComplexTypes
+from py3bindings.org.coursera.records.test.WithOptionalComplexTypesDefaultNone import WithOptionalComplexTypesDefaultNone
+from py3bindings.org.coursera.records.test.WithOptionalPrimitiveCustomTypes import WithOptionalPrimitiveCustomTypes
+from py3bindings.org.coursera.records.test.WithOptionalPrimitiveDefaultNone import WithOptionalPrimitiveDefaultNone
+from py3bindings.org.coursera.records.test.WithOptionalPrimitiveDefaults import WithOptionalPrimitiveDefaults
+from py3bindings.org.coursera.records.test.WithOptionalPrimitives import WithOptionalPrimitives
+from py3bindings.org.coursera.records.test.WithOptionalPrimitiveTyperefs import WithOptionalPrimitiveTyperefs
+from py3bindings.org.coursera.records.test.WithPrimitiveCustomTypes import WithPrimitiveCustomTypes
+from py3bindings.org.coursera.records.test.WithPrimitiveDefaults import WithPrimitiveDefaults
+from py3bindings.org.coursera.records.test.WithPrimitives import WithPrimitives
+from py3bindings.org.coursera.records.test.WithPrimitiveTyperefs import WithPrimitiveTyperefs
+from py3bindings.org.coursera.records.test.WithUnionWithInlineRecord import WithUnionWithInlineRecord
+from py3bindings.org.coursera.records.WithDateTime import WithDateTime
+from py3bindings.org.coursera.records.WithFlatTypedDefinition import WithFlatTypedDefinition
+from py3bindings.org.coursera.records.WithInclude import WithInclude
+from py3bindings.org.coursera.records.WithTypedDefinition import WithTypedDefinition
+from py3bindings.org.coursera.records.WithUnion import WithUnion
+from py3bindings.org.coursera.typerefs.ArrayTyperef import ArrayTyperef
+from py3bindings.org.coursera.typerefs.EnumTyperef import EnumTyperef
+from py3bindings.org.coursera.typerefs.FlatTypedDefinition import FlatTypedDefinition
+from py3bindings.org.coursera.typerefs.InlineRecord import InlineRecord
+from py3bindings.org.coursera.typerefs.InlineRecord2 import InlineRecord2
+from py3bindings.org.coursera.typerefs.IntTyperef import IntTyperef
+from py3bindings.org.coursera.typerefs.MapTyperef import MapTyperef
+from py3bindings.org.coursera.typerefs.RecordTyperef import RecordTyperef
+from py3bindings.org.coursera.typerefs.TypedDefinition import TypedDefinition
+from py3bindings.org.coursera.typerefs.Union import Union
+from py3bindings.org.coursera.typerefs.UnionTyperef import UnionTyperef
+from py3bindings.org.coursera.typerefs.UnionWithInlineRecord import UnionWithInlineRecord
+from py3bindings.org.coursera.unions.IntCustomType import IntCustomType
+from py3bindings.org.coursera.unions.IntTyperef import IntTyperef
+from py3bindings.org.coursera.unions.WithComplexTypesUnion import WithComplexTypesUnion
+from py3bindings.org.coursera.unions.WithCustomUnionTestId import WithCustomUnionTestId
+from py3bindings.org.coursera.unions.WithEmptyUnion import WithEmptyUnion
+from py3bindings.org.coursera.unions.WithPrimitiveCustomTypesUnion import WithPrimitiveCustomTypesUnion
+from py3bindings.org.coursera.unions.WithPrimitivesUnion import WithPrimitivesUnion
+from py3bindings.org.coursera.unions.WithPrimitiveTyperefsUnion import WithPrimitiveTyperefsUnion
+from py3bindings.org.coursera.unions.WithRecordCustomTypeUnion import WithRecordCustomTypeUnion
+from py3bindings.org.example.common.DateTime import DateTime
+from py3bindings.org.example.common.Timestamp import Timestamp
+from py3bindings.org.example.Fortune import Fortune
+from py3bindings.org.example.FortuneCookie import FortuneCookie
+from py3bindings.org.example.FortuneTelling import FortuneTelling
+from py3bindings.org.example.MagicEightBall import MagicEightBall
+from py3bindings.org.example.MagicEightBallAnswer import MagicEightBallAnswer
+from py3bindings.org.example.other.DateTime import DateTime
+from py3bindings.org.example.record import record
+from py3bindings.org.example.TyperefExample import TyperefExample
+from py3bindings.WithoutNamespace import WithoutNamespace
+
+import unittest
+
+
+class TestCourierBindings(unittest.TestCase):
+    def test_enum_find_by_name(self):
+        self.assertEqual(MagicEightBallAnswer.find_by_name('IT_IS_CERTAIN'), MagicEightBallAnswer.IT_IS_CERTAIN)
+        self.assertRaises(KeyError, lambda: MagicEightBallAnswer.find_by_name('Does not exist'))
+
+    def test_enum_all(self):
+        self.assertEqual(len(MagicEightBallAnswer.ALL), 3)
+        self.assertTrue(MagicEightBallAnswer.IT_IS_CERTAIN in MagicEightBallAnswer.ALL)
+        self.assertTrue(MagicEightBallAnswer.ASK_AGAIN_LATER in MagicEightBallAnswer.ALL)
+        self.assertTrue(MagicEightBallAnswer.OUTLOOK_NOT_SO_GOOD in MagicEightBallAnswer.ALL)
+
+    def test_enum_from_string(self):
+        good_answer = courier.loads(MagicEightBallAnswer, '"IT_IS_CERTAIN"')
+        self.assertEqual(good_answer, MagicEightBallAnswer.IT_IS_CERTAIN)
+        self.assertRaises(courier.ValidationError, lambda: courier.loads(MagicEightBallAnswer, '"WELL_THIS_DOESNT_EXIST"'))
+
+    def test_enum_empty(self):
+        self.assertEqual(len(EmptyEnum.ALL), 0)
+        self.assertRaises(KeyError, lambda: EmptyEnum.find_by_name('ANYTHING'))
+
+    def test_enum_properties(self):
+        """ TODO(py3) Not yet implemented in python bindings. This is stuff like:
+
+            enum EnumProperties {
+              @color = "red"
+              APPLE
+            }
+
+        """
+        pass
+
+    def test_record_json_dumps_and_loads(self):
+        question = 'Will I ever love again?'
+        answer = MagicEightBallAnswer.IT_IS_CERTAIN
+        eight_ball = MagicEightBall.create(question=question, answer=answer)
+        expected_json = """{"question": "Will I ever love again?", "answer": "IT_IS_CERTAIN"}"""
+        serialized_json = courier.dumps(eight_ball)
+        reloaded_eight_ball = courier.loads(MagicEightBall, serialized_json)
+        self.assertEqual(eight_ball.question, question)
+        self.assertEqual(eight_ball.answer, answer)
+        self.assertEqual(courier.dumps(eight_ball), expected_json)
+        self.assertEqual(reloaded_eight_ball, eight_ball)
+
+    def test_record_set_and_get(self):
+        question = 'Will I ever love again?'
+        answer = MagicEightBallAnswer.IT_IS_CERTAIN
+        eight_ball = MagicEightBall.create(question=question, answer=answer)
+        eight_ball.question = "??"
+        eight_ball.answer = MagicEightBallAnswer.ASK_AGAIN_LATER
+        self.assertEqual(eight_ball.question, "??")
+        self.assertEqual(eight_ball.answer, MagicEightBallAnswer.ASK_AGAIN_LATER)
+        self.assertEqual(courier.dumps(eight_ball), """{"question": "??", "answer": "ASK_AGAIN_LATER"}""")
+
+    def test_record_validate_shallow(self):
+        eight_ball = self.__make_eight_ball()
+        courier.validate(eight_ball) # should be valid immediately after creation
+        eight_ball.question = 1234
+        self.assertRaises(courier.ValidationError, lambda: courier.validate(eight_ball))
+
+        eight_ball = MagicEightBall({
+            'question': '??',
+            'answer': 'Well this isnt a valid enum'
+        })
+        self.assertRaises(courier.ValidationError, lambda: courier.validate(eight_ball))
+
+    def test_record_validate_deep(self):
+        pass
+
+    def test_record_with_typeref_field(self):
+        pass
+
+    def test_record_with_union_field(self):
+        pass
+
+    def test_record_with_list_field(self):
+        pass
+
+    def test_with_typed_definition(self):
+        """ TODO(py3): see reference suite WithFlatTypedDefinition.courier """
+        pass
+
+    def test_with_flat_typed_definition(self):
+        """ TODO(py3): see reference suite WithFlatTypedDefinition.courier """
+        pass
+
+    def test_record_without_namespace(self):
+        record = WithoutNamespace.create(field1="herp")
+        self.assertEqual(courier.loads(WithoutNamespace, courier.dumps(record)), record)
+
+    def test_record_with_reserved_name(self):
+        record = class_.create(private="herp")
+        self.assertEqual(courier.dumps(record), """{"private": "herp"}""")
+
+    def test_with_include(self):
+        """" TODO(py3): see reference suite WithInclude.courier """
+        pass
+
+    def test_json_property(self):
+        """" TODO(py3): Implement support for @json property.
+
+        But what does it do? It's supposed to work on a record like this:
+            @json = {
+              "negativeNumber": -3000000000
+            }
+            record JsonTest {
+            }
+
+        """
+        pass
+
+    def test_omit(self):
+        """" TODO(py3): Implement support for @py3.omit property
+
+        For those types that we don't support generation for yet. Looks like:
+
+            @py3.omit
+            record Message {
+              title: string?
+              body: string?
+            }
+        """
+        pass
+
+    def test_union(self):
+        union = WithComplexTypesUnion.Union.create(
+          py3bindings.org.coursera.records.test.Empty.Empty.create()
+        )
+
+        self.assertIsNone(union.as_Fruits)
+        self.assertIsNone(union.as_Simple_map)
+        self.assertIsNone(union.as_Simple_array)
+        self.assertIsNotNone(union.as_Empty)
+
+    def test_array_primitive(self):
+        ints = [1,2,3,4]
+        longs = [5,6,7,8]
+        floats = [9.0,10.0,11.0,12.0]
+        doubles = [13.0,14.0,15.0,16.0]
+        booleans = [True, False]
+        strings = ["seventeen", "eighteen"]
+
+        rec = WithPrimitivesArray.create(
+            ints = ints,
+            longs = longs,
+            floats = floats,
+            doubles = doubles,
+            booleans = booleans,
+            strings = strings,
+            bytes = []
+        )
+        courier.validate(rec) # should not throw
+        expected_str = """{"ints": [1, 2, 3, 4], "longs": [5, 6, 7, 8], "floats": [9.0, 10.0, 11.0, 12.0], "doubles": [13.0, 14.0, 15.0, 16.0], "booleans": [true, false], "strings": ["seventeen", "eighteen"], "bytes": []}"""
+
+        self.assertEqual(courier.dumps(rec), expected_str)
+        self.assertEqual(courier.loads(WithPrimitivesArray, expected_str), rec)
+
+        rec.ints = [100, 101]
+        self.assertTrue('"ints": [100, 101]' in courier.dumps(rec))
+
+    def test_array_and_map_complex(self):
+        custom_ints = [1, 2]
+        hello = Simple.create(message="Hello")
+        world = Simple.create(message="world")
+        bonjour = Simple.create(message="Bonjour")
+        tout_le_monde = Simple.create(message="tout le monde")
+        arrays = [[hello, world], [bonjour, tout_le_monde]]
+        maps = [
+          {'greeting': hello },
+          {'greeting': bonjour }
+        ]
+        unions = []
+        fixed = []
+        rec = WithCustomTypesArray.create(
+            ints = custom_ints,
+            arrays = arrays,
+            maps = maps,
+            unions = unions,
+            fixed = fixed
+        )
+        courier.validate(rec) # should not throw
+        json = """{"ints": [1, 2], "arrays": [[{"message": "Hello"}, {"message": "world"}], [{"message": "Bonjour"}, {"message": "tout le monde"}]], "maps": [{"greeting": {"message": "Hello"}}, {"greeting": {"message": "Bonjour"}}], "unions": [], "fixed": []}"""
+        self.assertEqual(courier.loads(WithCustomTypesArray, json), rec)
+
+        # Exercise the courier.Arrays
+        self.assertEqual(len(rec.arrays), 2)
+        self.assertEqual(rec.arrays[0][0], hello)
+        self.assertEqual(rec.arrays[0][1], world)
+        self.assertEqual(rec.arrays[1][0], bonjour)
+        self.assertEqual(rec.arrays[1][1], tout_le_monde)
+        for item in rec.arrays[0]:
+            self.assertTrue(item in [hello, world])
+        rec.arrays[0] = rec.arrays[1]
+        self.assertEqual(rec.arrays[0][0], bonjour)
+        self.assertEqual(2, len(rec.arrays))
+        rec.arrays.extend([rec.arrays[0], rec.arrays[0]])
+        self.assertEqual(4, len(rec.arrays))
+
+        # Exercise the courier.Maps
+        self.assertEqual(len(rec.maps), 2)
+        self.assertEqual(rec.maps[0]['greeting'], hello)
+        self.assertEqual(rec.maps[1]['greeting'], bonjour)
+        french_map = rec.maps[1]
+        self.assertRaises(KeyError, lambda: french_map['world'])
+        french_map['world'] = tout_le_monde
+        self.assertEqual(french_map['world'], tout_le_monde)
+        courier.dumps(rec)
+
+
+    def __make_eight_ball(self):
+        return MagicEightBall.create(
+            question='Will I ever love again?',
+            answer=MagicEightBallAnswer.IT_IS_CERTAIN
+        )
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python3/testsuite/src/runtests.py
+++ b/python3/testsuite/src/runtests.py
@@ -288,9 +288,11 @@ class TestCourierBindings(unittest.TestCase):
         self.assertEqual(union.value, py3bindings.org.coursera.records.test.Empty.Empty())
 
     def test_union_as_record_field(self):
+        # We should be able to set the union by any of its unioned types
         record = WithComplexTypesUnion(union=Fruits.APPLE)
         def assert_json_equal(json):
             self.assertEqual(courier.serialize(record), json)
+
         assert_json_equal("""{"union": {"org.coursera.enums.Fruits": "APPLE"}}""")
 
         record.union = Fruits.ORANGE
@@ -308,7 +310,7 @@ class TestCourierBindings(unittest.TestCase):
         # After raising, the union should still be in its last good state
         self.assertEqual(record.union, py3bindings.org.coursera.records.test.Empty.Empty())
 
-        # I should be able to set the union explicitly
+        # I should be able to set the union by explicitly using its Union type
         union = WithComplexTypesUnion.Union(Fruits.APPLE)
         record.union = union
         self.assertEqual(record.union, Fruits.APPLE)

--- a/python3/testsuite/src/runtests.py
+++ b/python3/testsuite/src/runtests.py
@@ -275,7 +275,7 @@ class TestCourierBindings(unittest.TestCase):
             @py3.omit
             record Message {
               title: string?
-              body: string?
+              body: string?a
             }
         """
         pass
@@ -286,6 +286,33 @@ class TestCourierBindings(unittest.TestCase):
         )
 
         self.assertEqual(union.value, py3bindings.org.coursera.records.test.Empty.Empty())
+
+    def test_union_as_record_field(self):
+        record = WithComplexTypesUnion(union=Fruits.APPLE)
+        def assert_json_equal(json):
+            self.assertEqual(courier.serialize(record), json)
+        assert_json_equal("""{"union": {"org.coursera.enums.Fruits": "APPLE"}}""")
+
+        record.union = Fruits.ORANGE
+        assert_json_equal("""{"union": {"org.coursera.enums.Fruits": "ORANGE"}}""")
+
+        record.union = py3bindings.org.coursera.records.test.Empty.Empty()
+        assert_json_equal("""{"union": {"org.coursera.records.test.Empty": {}}}""")
+
+
+        def bad_type_should_raise_value_error():
+            record.union = 1
+
+        self.assertRaises(ValueError, bad_type_should_raise_value_error)
+
+        # After raising, the union should still be in its last good state
+        self.assertEqual(record.union, py3bindings.org.coursera.records.test.Empty.Empty())
+
+        # I should be able to set the union explicitly
+        union = WithComplexTypesUnion.Union(Fruits.APPLE)
+        record.union = union
+        self.assertEqual(record.union, Fruits.APPLE)
+
 
     def test_array_primitive(self):
         ints = [1,2,3,4]

--- a/python3/testsuite/src/runtests.py
+++ b/python3/testsuite/src/runtests.py
@@ -157,9 +157,9 @@ class TestCourierBindings(unittest.TestCase):
         self.assertTrue(MagicEightBallAnswer.OUTLOOK_NOT_SO_GOOD in MagicEightBallAnswer.ALL)
 
     def test_enum_from_string(self):
-        good_answer = courier.loads(MagicEightBallAnswer, '"IT_IS_CERTAIN"')
+        good_answer = courier.parse(MagicEightBallAnswer, '"IT_IS_CERTAIN"')
         self.assertEqual(good_answer, MagicEightBallAnswer.IT_IS_CERTAIN)
-        self.assertRaises(courier.ValidationError, lambda: courier.loads(MagicEightBallAnswer, '"WELL_THIS_DOESNT_EXIST"'))
+        self.assertRaises(courier.ValidationError, lambda: courier.parse(MagicEightBallAnswer, '"WELL_THIS_DOESNT_EXIST"'))
 
     def test_enum_empty(self):
         self.assertEqual(len(EmptyEnum.ALL), 0)
@@ -181,11 +181,11 @@ class TestCourierBindings(unittest.TestCase):
         answer = MagicEightBallAnswer.IT_IS_CERTAIN
         eight_ball = MagicEightBall(question=question, answer=answer)
         expected_json = """{"question": "Will I ever love again?", "answer": "IT_IS_CERTAIN"}"""
-        serialized_json = courier.dumps(eight_ball)
-        reloaded_eight_ball = courier.loads(MagicEightBall, serialized_json)
+        serialized_json = courier.serialize(eight_ball)
+        reloaded_eight_ball = courier.parse(MagicEightBall, serialized_json)
         self.assertEqual(eight_ball.question, question)
         self.assertEqual(eight_ball.answer, answer)
-        self.assertEqual(courier.dumps(eight_ball), expected_json)
+        self.assertEqual(courier.serialize(eight_ball), expected_json)
         self.assertEqual(reloaded_eight_ball, eight_ball)
 
     def test_record_set_and_get(self):
@@ -196,7 +196,7 @@ class TestCourierBindings(unittest.TestCase):
         eight_ball.answer = MagicEightBallAnswer.ASK_AGAIN_LATER
         self.assertEqual(eight_ball.question, "??")
         self.assertEqual(eight_ball.answer, MagicEightBallAnswer.ASK_AGAIN_LATER)
-        self.assertEqual(courier.dumps(eight_ball), """{"question": "??", "answer": "ASK_AGAIN_LATER"}""")
+        self.assertEqual(courier.serialize(eight_ball), """{"question": "??", "answer": "ASK_AGAIN_LATER"}""")
 
     def test_record_validate_shallow(self):
         eight_ball = self.__make_eight_ball()
@@ -236,11 +236,11 @@ class TestCourierBindings(unittest.TestCase):
 
     def test_record_without_namespace(self):
         record = WithoutNamespace(field1="herp")
-        self.assertEqual(courier.loads(WithoutNamespace, courier.dumps(record)), record)
+        self.assertEqual(courier.parse(WithoutNamespace, courier.serialize(record)), record)
 
     def test_record_with_reserved_name(self):
         record = class_(private="herp")
-        self.assertEqual(courier.dumps(record), """{"private": "herp"}""")
+        self.assertEqual(courier.serialize(record), """{"private": "herp"}""")
 
     def test_with_include(self):
         """" TODO(py3): see reference suite WithInclude.courier """
@@ -302,11 +302,11 @@ class TestCourierBindings(unittest.TestCase):
         courier.validate(rec) # should not throw
         expected_str = """{"ints": [1, 2, 3, 4], "longs": [5, 6, 7, 8], "floats": [9.0, 10.0, 11.0, 12.0], "doubles": [13.0, 14.0, 15.0, 16.0], "booleans": [true, false], "strings": ["seventeen", "eighteen"], "bytes": []}"""
 
-        self.assertEqual(courier.dumps(rec), expected_str)
-        self.assertEqual(courier.loads(WithPrimitivesArray, expected_str), rec)
+        self.assertEqual(courier.serialize(rec), expected_str)
+        self.assertEqual(courier.parse(WithPrimitivesArray, expected_str), rec)
 
         rec.ints = [100, 101]
-        self.assertTrue('"ints": [100, 101]' in courier.dumps(rec))
+        self.assertTrue('"ints": [100, 101]' in courier.serialize(rec))
 
     def test_array_and_map_complex(self):
         custom_ints = [1, 2]
@@ -330,7 +330,7 @@ class TestCourierBindings(unittest.TestCase):
         )
         courier.validate(rec) # should not throw
         json = """{"ints": [1, 2], "arrays": [[{"message": "Hello"}, {"message": "world"}], [{"message": "Bonjour"}, {"message": "tout le monde"}]], "maps": [{"greeting": {"message": "Hello"}}, {"greeting": {"message": "Bonjour"}}], "unions": [], "fixed": []}"""
-        self.assertEqual(courier.loads(WithCustomTypesArray, json), rec)
+        self.assertEqual(courier.parse(WithCustomTypesArray, json), rec)
 
         # Exercise the courier.Arrays
         self.assertEqual(len(rec.arrays), 2)
@@ -354,7 +354,7 @@ class TestCourierBindings(unittest.TestCase):
         self.assertRaises(KeyError, lambda: french_map['world'])
         french_map['world'] = tout_le_monde
         self.assertEqual(french_map['world'], tout_le_monde)
-        courier.dumps(rec)
+        courier.serialize(rec)
 
 
     def __make_eight_ball(self):

--- a/python3/testsuite/src/runtests.py
+++ b/python3/testsuite/src/runtests.py
@@ -125,7 +125,7 @@ from py3bindings.org.coursera.unions.IntCustomType import IntCustomType
 from py3bindings.org.coursera.unions.IntTyperef import IntTyperef
 from py3bindings.org.coursera.unions.WithComplexTypesUnion import WithComplexTypesUnion
 from py3bindings.org.coursera.unions.WithCustomUnionTestId import WithCustomUnionTestId
-from py3bindings.org.coursera.unions.WithEmptyUnion import WithEmptyUnion
+# TODO(py3): Do we have to support this edge case? from py3bindings.org.coursera.unions.WithEmptyUnion import WithEmptyUnion
 from py3bindings.org.coursera.unions.WithPrimitiveCustomTypesUnion import WithPrimitiveCustomTypesUnion
 from py3bindings.org.coursera.unions.WithPrimitivesUnion import WithPrimitivesUnion
 from py3bindings.org.coursera.unions.WithPrimitiveTyperefsUnion import WithPrimitiveTyperefsUnion
@@ -281,8 +281,8 @@ class TestCourierBindings(unittest.TestCase):
         pass
 
     def test_union(self):
-        union = WithComplexTypesUnion.Union.create(
-          py3bindings.org.coursera.records.test.Empty.Empty()
+        union = WithComplexTypesUnion.Union(
+          value=py3bindings.org.coursera.records.test.Empty.Empty()
         )
 
         self.assertIsNone(union.as_Fruits)

--- a/python3/testsuite/src/runtests.py
+++ b/python3/testsuite/src/runtests.py
@@ -1,6 +1,4 @@
 import py3bindings.courier as courier
-import avro.io
-import avro.schema
 from py3bindings.org.coursera.arrays.WithAnonymousUnionArray import WithAnonymousUnionArray
 from py3bindings.org.coursera.arrays.WithCustomArrayTestId import WithCustomArrayTestId
 from py3bindings.org.coursera.arrays.WithCustomTypesArray import WithCustomTypesArray
@@ -146,28 +144,27 @@ from py3bindings.WithoutNamespace import WithoutNamespace
 
 import unittest
 
-
 class TestCourierBindings(unittest.TestCase):
-    def _test_enum_find_by_name(self):
+    def test_enum_find_by_name(self):
         self.assertEqual(MagicEightBallAnswer.find_by_name('IT_IS_CERTAIN'), MagicEightBallAnswer.IT_IS_CERTAIN)
         self.assertRaises(KeyError, lambda: MagicEightBallAnswer.find_by_name('Does not exist'))
 
-    def _test_enum_all(self):
+    def test_enum_all(self):
         self.assertEqual(len(MagicEightBallAnswer.ALL), 3)
         self.assertTrue(MagicEightBallAnswer.IT_IS_CERTAIN in MagicEightBallAnswer.ALL)
         self.assertTrue(MagicEightBallAnswer.ASK_AGAIN_LATER in MagicEightBallAnswer.ALL)
         self.assertTrue(MagicEightBallAnswer.OUTLOOK_NOT_SO_GOOD in MagicEightBallAnswer.ALL)
 
-    def _test_enum_from_string(self):
+    def test_enum_from_string(self):
         good_answer = courier.parse(MagicEightBallAnswer, '"IT_IS_CERTAIN"')
         self.assertEqual(good_answer, MagicEightBallAnswer.IT_IS_CERTAIN)
         self.assertRaises(courier.ValidationError, lambda: courier.parse(MagicEightBallAnswer, '"WELL_THIS_DOESNT_EXIST"'))
 
-    def _test_enum_empty(self):
+    def test_enum_empty(self):
         self.assertEqual(len(EmptyEnum.ALL), 0)
         self.assertRaises(KeyError, lambda: EmptyEnum.find_by_name('ANYTHING'))
 
-    def _test_enum_properties(self):
+    def test_enum_properties(self):
         """ TODO(py3) Not yet implemented in python bindings. This is stuff like:
 
             enum EnumProperties {
@@ -178,7 +175,7 @@ class TestCourierBindings(unittest.TestCase):
         """
         pass
 
-    def _test_record_json_dumps_and_loads(self):
+    def test_record_json_dumps_and_loads(self):
         question = 'Will I ever love again?'
         answer = MagicEightBallAnswer.IT_IS_CERTAIN
         eight_ball = MagicEightBall(question=question, answer=answer)
@@ -190,7 +187,7 @@ class TestCourierBindings(unittest.TestCase):
         self.assertEqual(courier.serialize(eight_ball), expected_json)
         self.assertEqual(reloaded_eight_ball, eight_ball)
 
-    def _test_record_set_and_get(self):
+    def test_record_set_and_get(self):
         question = 'Will I ever love again?'
         answer = MagicEightBallAnswer.IT_IS_CERTAIN
         eight_ball = MagicEightBall(question=question, answer=answer)
@@ -200,7 +197,7 @@ class TestCourierBindings(unittest.TestCase):
         self.assertEqual(eight_ball.answer, MagicEightBallAnswer.ASK_AGAIN_LATER)
         self.assertEqual(courier.serialize(eight_ball), """{"question": "??", "answer": "ASK_AGAIN_LATER"}""")
 
-    def _test_record_optional_field(self):
+    def test_record_optional_field(self):
         no_fields_from_data = courier.parse(WithOptionalPrimitives, '{}')
         no_fields_from_value = WithOptionalPrimitives()
         self.assertIsNone(no_fields_from_data.intField)
@@ -218,7 +215,7 @@ class TestCourierBindings(unittest.TestCase):
         int_field_from_value.intField = None
         self.assertEqual(courier.serialize(int_field_from_value), '{}')
 
-    def _test_record_default_primitives(self):
+    def test_record_default_primitives(self):
         num_defaults = NumericDefaults()
         self.assertEqual(num_defaults.i, 2147483647)
         self.assertEqual(num_defaults.l, 9223372036854775807)
@@ -237,7 +234,7 @@ class TestCourierBindings(unittest.TestCase):
 #            enumWithDefault=Fruits.APPLE
 #        )
 
-    def _test_courier_array_can_be_sliced(self):
+    def test_courier_array_can_be_sliced(self):
         """ There was a bug that caused slicing into an array of courier strings
         to produce a python array instead of another Courier array.
         
@@ -246,7 +243,7 @@ class TestCourierBindings(unittest.TestCase):
         courier_array = courier.Array(str, ['apples'])
         self.assertEqual(courier_array, courier_array[0:1])
 
-    def _test_record_validate_shallow(self):
+    def test_record_validate_shallow(self):
         eight_ball = self.__make_eight_ball()
         courier.validate(eight_ball) # should be valid immediately after creation
 
@@ -270,39 +267,39 @@ class TestCourierBindings(unittest.TestCase):
         self.assertRaises(courier.ValidationError, invalid_8ball_from_data)
         self.assertRaises(TypeError, invalid_8ball_from_construction)
 
-    def _test_record_validate_deep(self):
+    def test_record_validate_deep(self):
         pass
 
-    def _test_record_with_typeref_field(self):
+    def test_record_with_typeref_field(self):
         pass
 
-    def _test_record_with_union_field(self):
+    def test_record_with_union_field(self):
         pass
 
-    def _test_record_with_list_field(self):
+    def test_record_with_list_field(self):
         pass
 
-    def _test_with_typed_definition(self):
+    def test_with_typed_definition(self):
         """ TODO(py3): see reference suite WithFlatTypedDefinition.courier """
         pass
 
-    def _test_with_flat_typed_definition(self):
+    def test_with_flat_typed_definition(self):
         """ TODO(py3): see reference suite WithFlatTypedDefinition.courier """
         pass
 
-    def _test_record_without_namespace(self):
+    def test_record_without_namespace(self):
         record = WithoutNamespace(field1="herp")
         self.assertEqual(courier.parse(WithoutNamespace, courier.serialize(record)), record)
 
-    def _test_record_with_reserved_name(self):
+    def test_record_with_reserved_name(self):
         record = class_(private="herp")
         self.assertEqual(courier.serialize(record), """{"private": "herp"}""")
 
-    def _test_with_include(self):
+    def test_with_include(self):
         """" TODO(py3): see reference suite WithInclude.courier """
         pass
 
-    def _test_json_property(self):
+    def test_json_property(self):
         """" TODO(py3): Implement support for @json property.
 
         But what does it do? It's supposed to work on a record like this:
@@ -315,7 +312,7 @@ class TestCourierBindings(unittest.TestCase):
         """
         pass
 
-    def _test_omit(self):
+    def test_omit(self):
         """" TODO(py3): Implement support for @py3.omit property
 
         For those types that we don't support generation for yet. Looks like:
@@ -328,7 +325,7 @@ class TestCourierBindings(unittest.TestCase):
         """
         pass
 
-    def _test_union(self):
+    def test_union(self):
         union = WithComplexTypesUnion.Union(
           value=py3bindings.org.coursera.records.test.Empty.Empty()
         )
@@ -336,20 +333,63 @@ class TestCourierBindings(unittest.TestCase):
         self.assertEqual(union.value, py3bindings.org.coursera.records.test.Empty.Empty())
 
     def _test_union_with_fields_that_have_args(self):
-        """ TODO: This bug is not fixed. Fix it """
-        union = WithRecordCustomTypeUnion(Message('Hello, Simon!', 'Blabla'))
-        print('**** ', union)
+        """ CustomRecord is a ref to org.coursera.records.test.Message. However, when it appears
+        in a Union it should have its own name as key.
+        
+        TODO: BROKEN. currently it appears as the typerefed type instead of as itself. Fix this!
+        """
+        union = WithRecordCustomTypeUnion(CustomRecord('Hello, Simon!', 'Blabla'))
 
     def test_record_with_inline_union(self):
+        """
+        Assert this behavior from https://avro.apache.org/docs/1.8.1/spec.html
+        
+        In record, enum and fixed definitions, the fullname is determined in one
+        of the following ways:
+        
+        A name only is specified, i.e., a name that contains no dots. In this
+        case the namespace is taken from the most tightly enclosing schema or
+        protocol. For example, if "name": "X" is specified, and this occurs
+        within a field of the record definition of org.foo.Y, then the fullname
+        is org.foo.X. If there is no enclosing namespace then the null namespace
+        is used.
+        """
+        # Use RecordWithInlineUnion because the 'Note' class of the InlineUnion
+        # does not receive a namespace in the serialized SCHEMA.
         from py3bindings.org.coursera.records.RecordWithInlineUnion import RecordWithInlineUnion
 
-        # rec = RecordWithInlineUnion(RecordWithInlineUnion.InlineUnion(Note('Hello, Simon!')))
-        data = {'org.coursera.records.Note': { 'text': 'Name' }}
+        data = {'org.coursera.records.Note': { 'text': 'hello' }}
+
+        # Assembling the union by hand should be valid and accessible via the accessor
+        # without creating any sort of exception
+        rec = RecordWithInlineUnion(inlineUnion=Note(text='hello'))
+        self.assertEqual(rec.inlineUnion, Note(text='hello'))
+        self.assertEqual(rec, self._serdes(rec))
+
+        # Same with assembling it by data
+        rec = RecordWithInlineUnion(data={'inlineUnion': {'org.coursera.records.Note': { 'text': 'hello' }}})
+        self.assertEqual(rec.inlineUnion, Note(text='hello'))
+        self.assertEqual(rec, self._serdes(rec))
+
+        # Same with assembling it by its member type (not advised)
         un = RecordWithInlineUnion.InlineUnion(data=data)
         rec = RecordWithInlineUnion(un)
-        print('**** ', rec)
+        self.assertEqual(rec.inlineUnion, Note(text='hello'))
+        self.assertEqual(rec, self._serdes(rec))
 
-    def _test_union_as_record_field(self):
+        # Same with assembling it from its `string` conformation which should also not have a
+        # namespace in the schema
+        rec = RecordWithInlineUnion(inlineUnion='hello')
+        self.assertEqual(rec.inlineUnion, 'hello')
+        self.assertEqual(rec, self._serdes(rec))
+
+        # Same with assembling it from its 'MagicEightBallAnswer' conformation, which
+        # should have a namespace
+        rec = RecordWithInlineUnion(inlineUnion=MagicEightBallAnswer.ASK_AGAIN_LATER)
+        self.assertEqual(rec.inlineUnion, MagicEightBallAnswer.ASK_AGAIN_LATER)
+        self.assertEqual(rec, self._serdes(rec))
+
+    def test_union_as_record_field(self):
         # We should be able to set the union by any of its unioned types
         record = WithComplexTypesUnion(union=Fruits.APPLE)
         def assert_json_equal(json):
@@ -377,8 +417,9 @@ class TestCourierBindings(unittest.TestCase):
         record.union = union
         self.assertEqual(record.union, Fruits.APPLE)
 
-    def _test_union_of_arrays_and_maps(self):
+    def test_union_of_arrays_and_maps(self):
         record = WithComplexTypesUnion(union=[Simple('Hello world')])
+
         self.assertEqual(len(record.union), 1)
         self.assertEqual(record.union, [Simple('Hello world')])
 
@@ -390,7 +431,7 @@ class TestCourierBindings(unittest.TestCase):
         self.assertEqual(record.union['a'], Simple("a message"))
         self.assertEqual(courier.serialize(record), '{"union": {"map": {"a": {"message": "a message"}}}}')
 
-    def _test_array_primitive(self):
+    def test_array_primitive(self):
         ints = [1,2,3,4]
         longs = [5,6,7,8]
         floats = [9.0,10.0,11.0,12.0]
@@ -418,7 +459,7 @@ class TestCourierBindings(unittest.TestCase):
         rec.strings = rec.strings[0:1]
         self.assertTrue('"strings": ["seventeen"]' in courier.serialize(rec))
 
-    def _test_array_and_map_complex(self):
+    def test_array_and_map_complex(self):
         custom_ints = [1, 2]
         hello = Simple(message="Hello")
         world = Simple(message="world")
@@ -466,9 +507,11 @@ class TestCourierBindings(unittest.TestCase):
         self.assertEqual(french_map['world'], tout_le_monde)
         courier.serialize(rec)
 
-
     def __make_eight_ball(self):
         return MagicEightBall('Will I ever love again?', MagicEightBallAnswer.IT_IS_CERTAIN)
+
+    def _serdes(self, courier_obj):
+        return courier.parse(courier_obj.__class__, courier.serialize(courier_obj))
 
 if __name__ == '__main__':
     unittest.main()

--- a/python3/testsuite/src/runtests.py
+++ b/python3/testsuite/src/runtests.py
@@ -211,8 +211,15 @@ class TestCourierBindings(unittest.TestCase):
               'answer': 'Well this isnt a valid enum'
             })
 
+        def invalid_8ball_from_construction():
+            return MagicEightBall(
+                question="Will I ever love again?"
+                # missing answer
+            )
+
         self.assertRaises(courier.ValidationError, invalidate_eight_ball)
         self.assertRaises(courier.ValidationError, invalid_8ball_from_data)
+        self.assertRaises(TypeError, invalid_8ball_from_construction)
 
     def test_record_validate_deep(self):
         pass

--- a/python3/testsuite/src/runtests.py
+++ b/python3/testsuite/src/runtests.py
@@ -206,7 +206,7 @@ class TestCourierBindings(unittest.TestCase):
             eight_ball.question = 1234
 
         def invalid_8ball_from_data():
-            return MagicEightBall({
+            return MagicEightBall.from_data({
               'question': '??',
               'answer': 'Well this isnt a valid enum'
             })

--- a/python3/testsuite/src/runtests.py
+++ b/python3/testsuite/src/runtests.py
@@ -251,10 +251,10 @@ class TestCourierBindings(unittest.TestCase):
             eight_ball.question = 1234
 
         def invalid_8ball_from_data():
-            return MagicEightBall.from_data({
-              'question': '??',
-              'answer': 'Well this isnt a valid enum'
-            })
+            return courier.parse(MagicEightBall, """{
+              "question": "??",
+              "answer": "Well this isnt a valid enum"
+            }""")
 
         def invalid_8ball_from_construction():
             return MagicEightBall(

--- a/python3/testsuite/src/runtests.py
+++ b/python3/testsuite/src/runtests.py
@@ -179,7 +179,7 @@ class TestCourierBindings(unittest.TestCase):
     def test_record_json_dumps_and_loads(self):
         question = 'Will I ever love again?'
         answer = MagicEightBallAnswer.IT_IS_CERTAIN
-        eight_ball = MagicEightBall.create(question=question, answer=answer)
+        eight_ball = MagicEightBall(question=question, answer=answer)
         expected_json = """{"question": "Will I ever love again?", "answer": "IT_IS_CERTAIN"}"""
         serialized_json = courier.dumps(eight_ball)
         reloaded_eight_ball = courier.loads(MagicEightBall, serialized_json)
@@ -191,7 +191,7 @@ class TestCourierBindings(unittest.TestCase):
     def test_record_set_and_get(self):
         question = 'Will I ever love again?'
         answer = MagicEightBallAnswer.IT_IS_CERTAIN
-        eight_ball = MagicEightBall.create(question=question, answer=answer)
+        eight_ball = MagicEightBall(question=question, answer=answer)
         eight_ball.question = "??"
         eight_ball.answer = MagicEightBallAnswer.ASK_AGAIN_LATER
         self.assertEqual(eight_ball.question, "??")
@@ -201,14 +201,18 @@ class TestCourierBindings(unittest.TestCase):
     def test_record_validate_shallow(self):
         eight_ball = self.__make_eight_ball()
         courier.validate(eight_ball) # should be valid immediately after creation
-        eight_ball.question = 1234
-        self.assertRaises(courier.ValidationError, lambda: courier.validate(eight_ball))
 
-        eight_ball = MagicEightBall({
-            'question': '??',
-            'answer': 'Well this isnt a valid enum'
-        })
-        self.assertRaises(courier.ValidationError, lambda: courier.validate(eight_ball))
+        def invalidate_eight_ball():
+            eight_ball.question = 1234
+
+        def invalid_8ball_from_data():
+            return MagicEightBall({
+              'question': '??',
+              'answer': 'Well this isnt a valid enum'
+            })
+
+        self.assertRaises(courier.ValidationError, invalidate_eight_ball)
+        self.assertRaises(courier.ValidationError, invalid_8ball_from_data)
 
     def test_record_validate_deep(self):
         pass
@@ -231,11 +235,11 @@ class TestCourierBindings(unittest.TestCase):
         pass
 
     def test_record_without_namespace(self):
-        record = WithoutNamespace.create(field1="herp")
+        record = WithoutNamespace(field1="herp")
         self.assertEqual(courier.loads(WithoutNamespace, courier.dumps(record)), record)
 
     def test_record_with_reserved_name(self):
-        record = class_.create(private="herp")
+        record = class_(private="herp")
         self.assertEqual(courier.dumps(record), """{"private": "herp"}""")
 
     def test_with_include(self):
@@ -270,7 +274,7 @@ class TestCourierBindings(unittest.TestCase):
 
     def test_union(self):
         union = WithComplexTypesUnion.Union.create(
-          py3bindings.org.coursera.records.test.Empty.Empty.create()
+          py3bindings.org.coursera.records.test.Empty.Empty()
         )
 
         self.assertIsNone(union.as_Fruits)
@@ -286,7 +290,7 @@ class TestCourierBindings(unittest.TestCase):
         booleans = [True, False]
         strings = ["seventeen", "eighteen"]
 
-        rec = WithPrimitivesArray.create(
+        rec = WithPrimitivesArray(
             ints = ints,
             longs = longs,
             floats = floats,
@@ -306,10 +310,10 @@ class TestCourierBindings(unittest.TestCase):
 
     def test_array_and_map_complex(self):
         custom_ints = [1, 2]
-        hello = Simple.create(message="Hello")
-        world = Simple.create(message="world")
-        bonjour = Simple.create(message="Bonjour")
-        tout_le_monde = Simple.create(message="tout le monde")
+        hello = Simple(message="Hello")
+        world = Simple(message="world")
+        bonjour = Simple(message="Bonjour")
+        tout_le_monde = Simple(message="tout le monde")
         arrays = [[hello, world], [bonjour, tout_le_monde]]
         maps = [
           {'greeting': hello },
@@ -317,7 +321,7 @@ class TestCourierBindings(unittest.TestCase):
         ]
         unions = []
         fixed = []
-        rec = WithCustomTypesArray.create(
+        rec = WithCustomTypesArray(
             ints = custom_ints,
             arrays = arrays,
             maps = maps,
@@ -354,7 +358,7 @@ class TestCourierBindings(unittest.TestCase):
 
 
     def __make_eight_ball(self):
-        return MagicEightBall.create(
+        return MagicEightBall(
             question='Will I ever love again?',
             answer=MagicEightBallAnswer.IT_IS_CERTAIN
         )

--- a/python3/testsuite/src/runtests.py
+++ b/python3/testsuite/src/runtests.py
@@ -293,13 +293,13 @@ class TestCourierBindings(unittest.TestCase):
         def assert_json_equal(json):
             self.assertEqual(courier.serialize(record), json)
 
-        assert_json_equal("""{"union": {"org.coursera.enums.Fruits": "APPLE"}}""")
+        assert_json_equal('{"union": {"org.coursera.enums.Fruits": "APPLE"}}')
 
         record.union = Fruits.ORANGE
-        assert_json_equal("""{"union": {"org.coursera.enums.Fruits": "ORANGE"}}""")
+        assert_json_equal('{"union": {"org.coursera.enums.Fruits": "ORANGE"}}')
 
         record.union = py3bindings.org.coursera.records.test.Empty.Empty()
-        assert_json_equal("""{"union": {"org.coursera.records.test.Empty": {}}}""")
+        assert_json_equal('{"union": {"org.coursera.records.test.Empty": {}}}')
 
 
         def bad_type_should_raise_value_error():
@@ -315,6 +315,18 @@ class TestCourierBindings(unittest.TestCase):
         record.union = union
         self.assertEqual(record.union, Fruits.APPLE)
 
+    def test_union_of_arrays_and_maps(self):
+        record = WithComplexTypesUnion(union=[Simple('Hello world')])
+        self.assertEqual(len(record.union), 1)
+        self.assertEqual(record.union, [Simple('Hello world')])
+
+        record.union.append(Simple('Bonjour, tout le monde'))
+        self.assertEqual(len(record.union), 2)
+        self.assertEqual(record.union, [Simple('Hello world'), Simple('Bonjour, tout le monde')])
+        self.assertEqual(courier.serialize(record), '{"union": {"array": [{"message": "Hello world"}, {"message": "Bonjour, tout le monde"}]}}')
+        record.union = { 'a': Simple("a message") }
+        self.assertEqual(record.union['a'], Simple("a message"))
+        self.assertEqual(courier.serialize(record), '{"union": {"map": {"a": {"message": "a message"}}}}')
 
     def test_array_primitive(self):
         ints = [1,2,3,4]

--- a/python3/testsuite/src/runtests.py
+++ b/python3/testsuite/src/runtests.py
@@ -285,10 +285,7 @@ class TestCourierBindings(unittest.TestCase):
           value=py3bindings.org.coursera.records.test.Empty.Empty()
         )
 
-        self.assertIsNone(union.as_Fruits)
-        self.assertIsNone(union.as_Simple_map)
-        self.assertIsNone(union.as_Simple_array)
-        self.assertIsNotNone(union.as_Empty)
+        self.assertEqual(union.value, py3bindings.org.coursera.records.test.Empty.Empty())
 
     def test_array_primitive(self):
         ints = [1,2,3,4]

--- a/python3/testsuite/src/runtests.py
+++ b/python3/testsuite/src/runtests.py
@@ -74,7 +74,7 @@ from py3bindings.org.coursera.records.test.OptionalIntTyperef import OptionalInt
 from py3bindings.org.coursera.records.test.OptionalLongTyperef import OptionalLongTyperef
 from py3bindings.org.coursera.records.test.OptionalStringTyperef import OptionalStringTyperef
 from py3bindings.org.coursera.records.test.packaging.Empty import Empty
-# TODO(erem): Fix this from py3bindings.org.coursera.records.test.RecursivelyDefinedRecord import RecursivelyDefinedRecord
+# TODO(py3): Fix this from py3bindings.org.coursera.records.test.RecursivelyDefinedRecord import RecursivelyDefinedRecord
 from py3bindings.org.coursera.records.test.Simple import Simple
 from py3bindings.org.coursera.records.test.StringTyperef import StringTyperef
 from py3bindings.org.coursera.records.test.With22Fields import With22Fields

--- a/python3/testsuite/src/runtests.py
+++ b/python3/testsuite/src/runtests.py
@@ -262,10 +262,18 @@ class TestCourierBindings(unittest.TestCase):
                 # missing answer
             )
 
+        def invalid_8ball_acceptable_without_validation_flag():
+            return courier.parse(MagicEightBall, """{
+              "question": "??",
+              "answer": "Well this isnt a valid enum"
+            }""", validate=False)
+
         self.assertRaises(courier.ValidationError, invalidate_eight_ball)
         courier.validate(eight_ball) # the invalid changes should not have stuck
         self.assertRaises(courier.ValidationError, invalid_8ball_from_data)
         self.assertRaises(TypeError, invalid_8ball_from_construction)
+        invalid_8ball_acceptable_without_validation_flag() # throws if broken
+
 
     def test_record_validate_deep(self):
         pass

--- a/python3/testsuite/src/runtests.py
+++ b/python3/testsuite/src/runtests.py
@@ -216,6 +216,26 @@ class TestCourierBindings(unittest.TestCase):
         int_field_from_value.intField = None
         self.assertEqual(courier.serialize(int_field_from_value), '{}')
 
+    def test_record_default_primitives(self):
+        num_defaults = NumericDefaults()
+        self.assertEqual(num_defaults.i, 2147483647)
+        self.assertEqual(num_defaults.l, 9223372036854775807)
+        self.assertEqual(num_defaults.f, 3.4028233E38)
+        self.assertEqual(num_defaults.d, 1.7976931348623157E308)
+
+        data = {'intWithDefault': 1, 'longWithDefault': 3000000000, 'floatWithDefault': 3.3, 'doubleWithDefault': 4.4e+38, 'booleanWithDefault': True, 'stringWithDefault': 'DEFAULT', 'bytesWithDefault': bytes('', 'UTF-8'), 'enumWithDefault': 'APPLE'}
+        prim_defaults = WithPrimitiveDefaults(data=data)
+#            intWithDefault=1,
+#            longWithDefault=1,
+#            floatWithDefault=1.0,
+#            doubleWithDefault=1.0,
+#            booleanWithDefault=True,
+#            stringWithDefault="1",
+#            bytesWithDefault='\u00FF',
+#            enumWithDefault=Fruits.APPLE
+#        )
+
+
     def test_record_validate_shallow(self):
         eight_ball = self.__make_eight_ball()
         courier.validate(eight_ball) # should be valid immediately after creation

--- a/python3/testsuite/src/runtests.py
+++ b/python3/testsuite/src/runtests.py
@@ -235,6 +235,14 @@ class TestCourierBindings(unittest.TestCase):
 #            enumWithDefault=Fruits.APPLE
 #        )
 
+    def test_courier_array_can_be_sliced(self):
+        """ There was a bug that caused slicing into an array of courier strings
+        to produce a python array instead of another Courier array.
+        
+        This tests that we produce the courier.Array instead.
+        """
+        courier_array = courier.Array(str, ['apples'])
+        self.assertEqual(courier_array, courier_array[0:1])
 
     def test_record_validate_shallow(self):
         eight_ball = self.__make_eight_ball()

--- a/python3/testsuite/src/runtests.py
+++ b/python3/testsuite/src/runtests.py
@@ -218,6 +218,7 @@ class TestCourierBindings(unittest.TestCase):
             )
 
         self.assertRaises(courier.ValidationError, invalidate_eight_ball)
+        courier.validate(eight_ball) # the invalid changes should not have stuck
         self.assertRaises(courier.ValidationError, invalid_8ball_from_data)
         self.assertRaises(TypeError, invalid_8ball_from_construction)
 

--- a/reference-suite/src/main/courier/org/coursera/escaping/ReservedClassFieldEscaping.courier
+++ b/reference-suite/src/main/courier/org/coursera/escaping/ReservedClassFieldEscaping.courier
@@ -5,4 +5,5 @@ record ReservedClassFieldEscaping {
   schema: string
   copy: string
   clone: string
+  pass: string?
 }

--- a/reference-suite/src/main/courier/org/coursera/records/RecordWithInlineUnion.courier
+++ b/reference-suite/src/main/courier/org/coursera/records/RecordWithInlineUnion.courier
@@ -1,0 +1,5 @@
+namespace org.coursera.records
+
+record RecordWithInlineUnion {
+  inlineUnion: union[Note]
+}

--- a/reference-suite/src/main/courier/org/coursera/records/RecordWithInlineUnion.courier
+++ b/reference-suite/src/main/courier/org/coursera/records/RecordWithInlineUnion.courier
@@ -1,5 +1,7 @@
 namespace org.coursera.records
 
+import org.example.MagicEightBallAnswer
+
 record RecordWithInlineUnion {
-  inlineUnion: union[Note]
+  inlineUnion: union[Note, string, MagicEightBallAnswer]
 }

--- a/scala/generator-test/src/test/scala/org/coursera/courier/generator/GeneratorTest.scala
+++ b/scala/generator-test/src/test/scala/org/coursera/courier/generator/GeneratorTest.scala
@@ -71,7 +71,7 @@ abstract class GeneratorTest extends JUnitSuite with AssertionsForJUnit {
 
   private def listToJson(dataList: DataList): String = prettyPrinter.listToString(dataList)
 
-  private def readJsonToMap(string: String): DataMap = dataCodec.stringToMap(string)
+  def readJsonToMap(string: String): DataMap = dataCodec.stringToMap(string)
 
   private def readJsonToList(string: String): DataList = dataCodec.stringToList(string)
 }


### PR DESCRIPTION
**WORK IN PROGRESS DO NOT MERGE**

[Discussion here](https://github.com/coursera/courier/issues/52)

Python3 Courier Data Binding Generator
==============================================

Courier bindings for Python 3 (tested against Python 3.6)

Features missing in action
--------------------------

Mainline Courier features that are not yet supported, but will be by the time
this thing is ready for submit:
  - [ ] **Coercers**
  - [ ] **Non-primitive keyed maps**. Hashcode not yet implemented for
        non-primitives.
  - [ ] **Non-JSON serialization**. Though avro should be trivial with existing
        avro libraries.
  - [x] **Default values**.
  - [ ] **Flat-typed definitions**.
  - [x] **Optional fields**. Currently all fields in `MyRecord.create` are
        required. These should be easy to add.
  - [ ] **Deprecation**.
  - [ ] **Enum properties**. No `Fruits.BANANA.property("color")`
  - [ ] **$UNKNOWN** on enums.
  
Additional tasks before merging to courier master:
  - [ ] Fix the most heinous `TODO(py3)` items from the changelist.
    - Specifically the ones that alter the general, not-only-py3 code.
  - [ ] Hook into the top-level cli
  - [ ] Many additional test-cases
  - [ ] Populate this documentation
  - [ ] Import classes via the package's `__init__.py` rather than per-class files
  
Additional desirable tasks for later:
  - [ ] Ship `courier.py` as a package through `pip` instead of through the
        generator
  - [ ] Examine abstractions that unify code the large amount of overlap between TSLite and Python3 code generation. Hopefully this can lead to writing new bindings more easily down the road.

Pythonic API Questions
-----------------------

  * What is the least surprising approach to mutability of data? Is it pythonic to expect that setting `cookie.fortune.message = 'Hello World'` will change the json value of `courier.dumps(cookie)`?
  * What is the least surprising approach to validation? I'm currently thinking to validate on:
     - `courier.loads(MyRecordType, json_string`)
     - `courier.validate(my_record)` of course
     - But we could also validate immediately after setting any field. This would end up being really expensive if setting fields in a loop, but would be maximally useful during development since py lacks a type system.

Notes from interviews with a _real python dev_:
  - [x] instead of dumps / loads use parse / serialize
  - [x] It strikes a better balance for python users to put the natural constructor args as optional named parameters to __init__, rather than as required/optional parameters on `create`. Instead, just enforce the contract in the init function itself, throwing a courier.ValidationError
  - [x] Is useful to throw validation errors when a bad value is set into a courier record
    - if you try to set, and throw a validation error, it should keep the _old_ version of the data (before the set)
  - [x] Is it possible to make the union actually _behave_ like a union of the constituent types? e.g. 
     my_union = /* get the union of Cookie | FortuneCookie */ 
     my_union.calories
  - [x] Absence of a required field should throw a `AttributeError` or whatever the right one is