### PR TITLE
Should the Record unapply method always return Some?

### DIFF
--- a/scala/generator-test/src/test/scala/org/coursera/courier/generator/RecordGeneratorTest.scala
+++ b/scala/generator-test/src/test/scala/org/coursera/courier/generator/RecordGeneratorTest.scala
@@ -26,6 +26,7 @@ import org.coursera.records.test.Empty
 import org.coursera.records.test.Empty2
 import org.coursera.records.test.InlineOptionalRecord
 import org.coursera.records.test.InlineRecord
+import org.coursera.records.test.Message
 import org.coursera.records.test.Simple
 import org.coursera.records.test.SimpleMap
 import org.coursera.records.test.WithComplexTypeDefaults
@@ -470,4 +471,17 @@ class RecordGeneratorTest extends GeneratorTest with SchemaFixtures {
     // Fortunately, nothing should depend solely on hashCode() for determining whether two
     // records match.
   }
+
+  @Test
+  def testUnapplyReturnsSomeType(): Unit = {
+    // If the unapply method returns Option[X] instead of Some[X], then the scala compiler turns
+    // off match exhaustivity checking for match statements that use the unapply method. This test
+    // This test asserts that the unapply method returns Some[X], so that we get better
+    // exhaustivity checking for match statements involving courier records.
+    assertCompiles("""
+      val record = Message("hello", "hello world")
+      Message.unapply(record): Some[(String, String)]
+    """)
+  }
+
 }

--- a/scala/generator/src/main/twirl/org/coursera/courier/templates/RecordClass.scala.txt
+++ b/scala/generator/src/main/twirl/org/coursera/courier/templates/RecordClass.scala.txt
@@ -203,13 +203,8 @@ object @(record.scalaType) extends RecordCompanion[@(record.scalaType)] {
       def unapply(record: @(record.scalaType)): Boolean = true
     }
     case i if i <= 22 => { @* Scala tuples only exist up to Tuple22. *@
-      def unapply(record: @(record.scalaType)): Option[(@(record.fieldsAsTypeParams))] = {
-        try {
-          Some((@(record.prefixedFieldParams("record."))))
-        } catch {
-          case cast: TemplateOutputCastException => None
-          case notPresent: RequiredFieldNotPresentException => None
-        }
+      def unapply(record: @(record.scalaType)): Some[(@(record.fieldsAsTypeParams))] = {
+        Some((@(record.prefixedFieldParams("record."))))
       }
     }
     case _ => {


### PR DESCRIPTION
Similar to #46.

I had a courier record `Foo { bar: Bar? }` and I used it to write a bug:
```
foo match {
  case Foo(Some(bar)) => doStuff(bar)
}
```
The bug is that the match is not exhaustive. The scala exhaustivity checker would have caught this if `Foo`'s generated `unapply` method had return type `Some[Foo]` instead of `Option[Foo]`.

Unfortunately, the `unapply` method in the `RecordClass.scala.txt` template has some ways of returning `None`, which I had to remove in order to make this work.

I don't really understand why the catching that used to be there is necessary. Surely when you have an instance of a record, returning all of its fields should always succeed? If that's true, then the catching is not necessary.

(sorry I accidentally closed #54 and I don't know how to reopen it, so this is just a duplicate of #54)