### PR TITLE
Allow apostrophes in single-line comments

### DIFF
--- a/gradle-plugin/gradle.properties
+++ b/gradle-plugin/gradle.properties
@@ -1,2 +1,2 @@
-courierVersion=2.0.10
+courierVersion=2.0.11
 scalaMajorVersion=2.11

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -35,7 +35,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <scalaMajorVersion>2.11</scalaMajorVersion>
     <scalaVersion>2.11.5</scalaVersion>
-    <courierVersion>2.0.10</courierVersion>
+    <courierVersion>2.0.11</courierVersion>
     <javaVersion>1.7</javaVersion>
   </properties>
   <url>http://github.com/coursera/courier</url>

--- a/reference-suite/src/main/courier/org/example/Apostrophe.courier
+++ b/reference-suite/src/main/courier/org/example/Apostrophe.courier
@@ -1,0 +1,6 @@
+namespace org.example
+
+record Apostrophe {
+  // A single-line comment on the record's field can contain apostrophes.
+  field: int
+}

--- a/reference-suite/src/main/pegasus/org/example/Apostrophe.pdsc
+++ b/reference-suite/src/main/pegasus/org/example/Apostrophe.pdsc
@@ -1,0 +1,11 @@
+{
+  "type": "record",
+  "name": "Apostrophe",
+  "namespace": "org.example",
+  "fields": [
+    {
+      "name": "field",
+      "type": "int"
+    }
+  ]
+}

--- a/schema-language/src/main/antlr4/Courier.g4
+++ b/schema-language/src/main/antlr4/Courier.g4
@@ -158,7 +158,7 @@ NULL_LITERAL: 'null';
 
 SCHEMADOC_COMMENT: '/**' .*? '*/';
 BLOCK_COMMENT: '/*' .*? '*/' -> skip;
-LINE_COMMENT: '//' ~['\r\n']* -> skip;
+LINE_COMMENT: '//' ~[\r\n]* -> skip;
 
 NUMBER_LITERAL: '-'? ('0' | [1-9] [0-9]*) ( '.' [0-9]+)? ([eE][+-]?[0-9]+)?;
 

--- a/schema-language/src/test/java/org/coursera/courier/grammar/ConversionTest.java
+++ b/schema-language/src/test/java/org/coursera/courier/grammar/ConversionTest.java
@@ -35,6 +35,7 @@ public class ConversionTest {
   public void courierToPdsc() throws IOException {
 
     String[] schemasNames = new String[] {
+      "org.example.Apostrophe",
       "org.example.Fortune",
       "org.example.FortuneCookie",
       "org.example.MagicEightBall",

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.0.10" 
+version in ThisBuild := "2.0.11"


### PR DESCRIPTION
Updates the schema language grammar to allow apostrophes in single-line comments.
Fixes #38.