### PR TITLE
Generate unapply methods that don't trigger the unused parameter warning in Scala

### DIFF
--- a/gradle-plugin/gradle.properties
+++ b/gradle-plugin/gradle.properties
@@ -1,2 +1,2 @@
-courierVersion=2.0.12
+courierVersion=2.0.13
 scalaMajorVersion=2.11

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -35,7 +35,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <scalaMajorVersion>2.11</scalaMajorVersion>
     <scalaVersion>2.11.5</scalaVersion>
-    <courierVersion>2.0.12</courierVersion>
+    <courierVersion>2.0.13</courierVersion>
     <javaVersion>1.7</javaVersion>
   </properties>
   <url>http://github.com/coursera/courier</url>

--- a/scala/generator/src/main/twirl/org/coursera/courier/templates/RecordClass.scala.txt
+++ b/scala/generator/src/main/twirl/org/coursera/courier/templates/RecordClass.scala.txt
@@ -201,7 +201,10 @@ object @(record.scalaType) extends RecordCompanion[@(record.scalaType)] {
   @* Scala, why you make unapply so complicated? *@
   @record.fields.size match {
     case 0 => {
-      def unapply(record: @(record.scalaType)): Boolean = true
+      def unapply(record: @(record.scalaType)): Boolean = {
+        val _ = record // prevents warning about unused parameter
+        true
+      }
     }
     case i if i <= 22 => { @* Scala tuples only exist up to Tuple22. *@
       def unapply(record: @(record.scalaType)): Option[(@(record.fieldsAsTypeParams))] = {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.0.12"
+version in ThisBuild := "2.0.13"


### PR DESCRIPTION
For empty records, Courier currently generates `unapply` methods that look like this:
```
def unapply(record: SomeRecordType): Boolean = true
```

After this change, those methods will look like this:
```
def unapply(record: SomeRecordType): Boolean = {
  val _ = record // prevents warning about unused parameter
  true
}
```

Fixes #58.