### PR TITLE
Fix bug preventing DataTemplates.readRecord from processing generated templates

### DIFF
--- a/scala/generator-test/src/test/scala/org/coursera/courier/generator/RecordGeneratorTest.scala
+++ b/scala/generator-test/src/test/scala/org/coursera/courier/generator/RecordGeneratorTest.scala
@@ -470,4 +470,15 @@ class RecordGeneratorTest extends GeneratorTest with SchemaFixtures {
     // Fortunately, nothing should depend solely on hashCode() for determining whether two
     // records match.
   }
+
+  @Test
+  def testDataTemplateHelperCompatibility(): Unit = {
+    // DataTemplates provides a bunch of convenient helper methods for
+    // serializing and deserializing records. Let's make sure the generated
+    // records are compatible with those methods.
+    val origRecord = Simple(Some("Hi"))
+    val jsString = DataTemplates.writeRecord(origRecord)
+    val roundTrippedRecord = DataTemplates.readRecord[Simple](jsString)
+    assert(origRecord === roundTrippedRecord)
+  }
 }

--- a/scala/generator-test/src/test/scala/org/coursera/courier/generator/UnionGeneratorTest.scala
+++ b/scala/generator-test/src/test/scala/org/coursera/courier/generator/UnionGeneratorTest.scala
@@ -155,4 +155,16 @@ class UnionGeneratorTest extends GeneratorTest with SchemaFixtures {
   def testUnionTyperefSchema(): Unit = {
     assert(TypedDefinition.TYPEREF_SCHEMA.getDereferencedDataSchema === TypedDefinition.SCHEMA)
   }
+
+  @Test
+  def testDataTemplateHelperSupport(): Unit = {
+    // DataTemplates provides a bunch of convenient helper methods for
+    // serializing and deserializing unions. Let's make sure the generated
+    // unions are compatible with those methods.
+    val origMember = WithPrimitiveCustomTypesUnion.Union.CustomIntMember(CustomInt(1))
+    val original = WithPrimitiveCustomTypesUnion(origMember)
+    val json = DataTemplates.writeUnion(origMember)
+    val roundTripped = DataTemplates.readUnion[WithPrimitiveCustomTypesUnion.Union](json)
+    assert(origMember === roundTripped)
+  }
 }

--- a/scala/runtime/src/main/scala/org/coursera/courier/templates/DataTemplates.scala
+++ b/scala/runtime/src/main/scala/org/coursera/courier/templates/DataTemplates.scala
@@ -213,23 +213,23 @@ object DataTemplates {
   private[this] def newDataMapTemplate[T <: DataTemplate[DataMap]](
       data: DataMap, clazz: Class[T]): T = {
     val companionInstance = companion(clazz)
-    val applyMethod = getTemplateDataConstructor(companionInstance, classOf[DataMap])
+    val buildMethod = getTemplateDataConstructor(companionInstance, classOf[DataMap])
 
-    applyMethod.invoke(companionInstance, data, DataConversion.SetReadOnly).asInstanceOf[T]
+    buildMethod.invoke(companionInstance, data, DataConversion.SetReadOnly).asInstanceOf[T]
   }
 
   private[this] def newDataListTemplate[T <: DataTemplate[DataList]](
       data: DataList, clazz: Class[T]): T = {
     val companionInstance = companion(clazz)
-    val applyMethod = getTemplateDataConstructor(companionInstance, classOf[DataList])
-    applyMethod.invoke(companionInstance, data, DataConversion.SetReadOnly).asInstanceOf[T]
+    val buildMethod = getTemplateDataConstructor(companionInstance, classOf[DataList])
+    buildMethod.invoke(companionInstance, data, DataConversion.SetReadOnly).asInstanceOf[T]
   }
 
   private[this] def newUnionTemplate[T <: UnionTemplate](data: DataMap, clazz: Class[T]): T = {
     val companionInstance = companion(clazz)
-    val applyMethod = getTemplateDataConstructor(companionInstance, classOf[DataMap])
+    val buildMethod = getTemplateDataConstructor(companionInstance, classOf[DataMap])
 
-    applyMethod.invoke(companionInstance, data, DataConversion.SetReadOnly).asInstanceOf[T]
+    buildMethod.invoke(companionInstance, data, DataConversion.SetReadOnly).asInstanceOf[T]
   }
 
   /**

--- a/scala/runtime/src/test/scala/org/coursera/courier/codecs/InlineStringCodecTest.scala
+++ b/scala/runtime/src/test/scala/org/coursera/courier/codecs/InlineStringCodecTest.scala
@@ -33,9 +33,9 @@ import com.linkedin.data.template.DataTemplateUtil
 import org.coursera.courier.templates.DataTemplates
 import org.coursera.courier.templates.DataValidationException
 import org.junit.Test
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatest.junit.{AssertionsForJUnit, JUnitSuite}
 
-class InlineStringCodecTest extends AssertionsForJUnit {
+class InlineStringCodecTest extends JUnitSuite with AssertionsForJUnit {
 
   @Test
   def testPrimitives(): Unit = {

--- a/scala/runtime/src/test/scala/org/coursera/courier/templates/DataTemplatesTest.scala
+++ b/scala/runtime/src/test/scala/org/coursera/courier/templates/DataTemplatesTest.scala
@@ -23,40 +23,91 @@ import com.linkedin.data.schema.UnionDataSchema
 import com.linkedin.data.template.DataTemplateUtil
 import com.linkedin.data.template.RecordTemplate
 import com.linkedin.data.template.UnionTemplate
+import org.coursera.courier.data.IntArray
 import org.coursera.courier.templates.DataTemplates.DataConversion
-import org.scalatest.junit.AssertionsForJUnit
+import org.scalatest.junit.{AssertionsForJUnit, JUnitSuite}
 import org.junit.Test
 
-class DataTemplatesTest extends AssertionsForJUnit {
+class DataTemplatesTest extends JUnitSuite with AssertionsForJUnit {
   import DataTemplatesTest._
+
+  @Test
+  def readWriteLegacyRecord(): Unit = {
+    val json = """{"string":"a","int":1}"""
+    val record = DataTemplates.readRecord[MockLegacyRecord](json)
+    val roundTripped = DataTemplates.writeRecord(record)
+    assert(DataTemplates.readDataMap(roundTripped) === DataTemplates.readDataMap(json))
+  }
 
   @Test
   def readWriteRecord(): Unit = {
     val json = """{"string":"a","int":1}"""
-    val union = DataTemplates.readRecord[MockRecord](json)
-    val roundTripped = DataTemplates.writeRecord(union)
+    val record = DataTemplates.readRecord[MockRecord](json)
+    val roundTripped = DataTemplates.writeRecord(record)
     assert(DataTemplates.readDataMap(roundTripped) === DataTemplates.readDataMap(json))
   }
 
   @Test
   def readWriteUnion(): Unit = {
     val json = """{"int":1}"""
-    val union = DataTemplates.readUnion[MockTyperefUnion](json)
+    val union = DataTemplates.readUnion[MockLegacyTyperefUnion](json)
+    val roundTripped = DataTemplates.writeUnion(union)
+    assert(DataTemplates.readDataMap(roundTripped) === DataTemplates.readDataMap(json))
+  }
+
+  @Test
+  def readWriteLegacyUnion(): Unit = {
+    val json = """{"int":1}"""
+    val union = DataTemplates.readUnion[MockLegacyTyperefUnion](json)
     val roundTripped = DataTemplates.writeUnion(union)
     assert(DataTemplates.readDataMap(roundTripped) === DataTemplates.readDataMap(json))
   }
 
   @Test
   def testGetSchema(): Unit = {
-    val schemaFromClass = DataTemplates.getSchema(classOf[MockRecord])
-    assert(schemaFromClass === MockRecord.SCHEMA)
+    val schemaFromClass = DataTemplates.getSchema(classOf[MockLegacyRecord])
+    assert(schemaFromClass === MockLegacyRecord.SCHEMA)
 
-    val schemaFromClassTag = DataTemplates.getSchema[MockRecord]
-    assert(schemaFromClassTag === MockRecord.SCHEMA)
+    val schemaFromClassTag = DataTemplates.getSchema[MockLegacyRecord]
+    assert(schemaFromClassTag === MockLegacyRecord.SCHEMA)
+  }
+
+  @Test
+  def testReadWriteArray(): Unit = {
+    val array = "[1,2,3,4,5]"
+    val read = DataTemplates.readArray[IntArray](array)
+    val written = DataTemplates.writeArray(read)
+    assert(array === written)
   }
 }
 
 object DataTemplatesTest {
+  class MockLegacyRecord(private val dataMap: DataMap)
+    extends RecordTemplate(dataMap, MockLegacyRecord.SCHEMA) {
+    dataMap.makeReadOnly()
+  }
+
+  object MockLegacyRecord {
+    val SCHEMA_JSON =
+      """
+        |{
+        |  "name": "MockLegacyRecord",
+        |  "type": "record",
+        |  "fields": [
+        |    { "name": "string", "type": "string" },
+        |    { "name": "int", "type": "int" }
+        |  ]
+        |}
+        |""".stripMargin
+
+    val SCHEMA = DataTemplateUtil.parseSchema(SCHEMA_JSON).asInstanceOf[RecordDataSchema]
+
+    def apply(dataMap: DataMap, dataConversion: DataConversion) = {
+      new MockLegacyRecord(dataMap)
+    }
+  }
+
+  /** Like MockRecord, but has `build` instead of `apply`, as per */
   class MockRecord(private val dataMap: DataMap)
     extends RecordTemplate(dataMap, MockRecord.SCHEMA) {
     dataMap.makeReadOnly()
@@ -77,8 +128,38 @@ object DataTemplatesTest {
 
     val SCHEMA = DataTemplateUtil.parseSchema(SCHEMA_JSON).asInstanceOf[RecordDataSchema]
 
-    def apply(dataMap: DataMap, dataConversion: DataConversion) = {
+    def build(dataMap: DataMap, dataConversion: DataConversion) = {
       new MockRecord(dataMap)
+    }
+  }
+
+  class MockLegacyTyperefUnion(private val dataMap: DataMap)
+    extends UnionTemplate(dataMap, MockLegacyTyperefUnion.SCHEMA) {
+    dataMap.makeReadOnly()
+  }
+
+  object MockLegacyTyperefUnion {
+    val SCHEMA_JSON =
+      """
+        |[ "int", "string" ]
+        |""".stripMargin
+
+    val SCHEMA = DataTemplateUtil.parseSchema(SCHEMA_JSON).asInstanceOf[UnionDataSchema]
+
+    val TYPEREF_SCHEMA_JSON =
+      """
+        |{
+        |  "name": "MockTyperefUnion",
+        |  "type": "typeref",
+        |  "ref": [ "int", "string" ]
+        |}
+        |""".stripMargin
+
+    val TYPEREF_SCHEMA =
+      DataTemplateUtil.parseSchema(TYPEREF_SCHEMA_JSON).asInstanceOf[TyperefDataSchema]
+
+    def apply(dataMap: DataMap, dataConversion: DataConversion) = {
+      new MockLegacyTyperefUnion(dataMap)
     }
   }
 


### PR DESCRIPTION
Adds test-cases to reproduce the bug described in #72, and fixes that bug.

Also enables the test-cases in the `scala-runtime` build unit. I don't think they were ever running!