### PR TITLE
Adds generator mixin capability so that we can customize template generation for Coursera

### DIFF
--- a/cli/src/main/scala/org/coursera/courier/cli/CourierCli.scala
+++ b/cli/src/main/scala/org/coursera/courier/cli/CourierCli.scala
@@ -1,7 +1,7 @@
 package org.coursera.courier.cli
 
 import org.coursera.courier.generator.ScalaDataTemplateGenerator
-import org.coursera.courier.{AndroidGenerator, JavaGenerator, ScalaGenerator, SwiftGenerator, TypeScriptLiteGenerator}
+import org.coursera.courier.{AndroidGenerator, JavaGenerator, SwiftGenerator, TypeScriptLiteGenerator}
 
 object CourierCli extends App {
   val maybeSubcommandResult = for {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -30,13 +30,12 @@ import sbtassembly.AssemblyKeys._
 import sbtassembly.AssemblyPlugin.defaultShellScript
 
 /**
- * SBT project for Courier.
- */
+  * SBT project for Courier.
+  */
 object Courier extends Build with OverridablePublishSettings {
 
   override lazy val settings = super.settings ++ overridePublishSettings ++
-      Seq(
-        organization := "org.coursera.courier")
+    Seq(organization := "org.coursera.courier")
 
   //
   // Cross building
@@ -57,7 +56,9 @@ object Courier extends Build with OverridablePublishSettings {
   // We cross build our runtime to both versions.
   lazy val runtimeVersionSettings = Seq(
     scalaVersion in ThisBuild := currentScalaVersion,
-    crossScalaVersions in ThisBuild := Seq(sbtScalaVersion, "2.11.11", currentScalaVersion))
+    crossScalaVersions in ThisBuild := Seq(sbtScalaVersion,
+                                           "2.11.11",
+                                           currentScalaVersion))
 
   // Strictly speaking, our generator only needs to be built for the SBT plugin Scala version.
   // But we also cross built it to the current Scala version so that our generator-test
@@ -66,7 +67,8 @@ object Courier extends Build with OverridablePublishSettings {
   // Scala version.
   lazy val generatorVersionSettings = Seq(
     scalaVersion in ThisBuild := sbtScalaVersion,
-    crossScalaVersions in ThisBuild := Seq(sbtScalaVersion, currentScalaVersion))
+    crossScalaVersions in ThisBuild := Seq(sbtScalaVersion,
+                                           currentScalaVersion))
 
   // Java project settings
   lazy val plainJavaProjectSettings = Seq(
@@ -86,91 +88,109 @@ object Courier extends Build with OverridablePublishSettings {
       System.setProperty(
         "referencesuite.srcdir",
         (sourceDirectory in referenceSuite).value.getAbsolutePath)
-    })
+    }
+  )
 
   //
   // Projects
   //
-  lazy val schemaLanguage = Project(id = "schema-language", base = file("schema-language"))
-    .disablePlugins(bintray.BintrayPlugin)
+  lazy val schemaLanguage =
+    Project(id = "schema-language", base = file("schema-language"))
+      .disablePlugins(bintray.BintrayPlugin)
 
-  lazy val generatorApi = Project(id = "generator-api", base = file("generator-api"))
-    .dependsOn(schemaLanguage)
-    .disablePlugins(bintray.BintrayPlugin)
+  lazy val generatorApi =
+    Project(id = "generator-api", base = file("generator-api"))
+      .dependsOn(schemaLanguage)
+      .disablePlugins(bintray.BintrayPlugin)
 
-  lazy val referenceSuite = Project(id = "reference-suite", base = file("reference-suite"))
-    .disablePlugins(bintray.BintrayPlugin)
+  lazy val referenceSuite =
+    Project(id = "reference-suite", base = file("reference-suite"))
+      .disablePlugins(bintray.BintrayPlugin)
 
   private[this] val scalaDir = file("scala")
 
-  lazy val scalaGenerator = Project(id = "scala-generator", base = scalaDir / "generator")
-    .dependsOn(scalaRuntime, generatorApi, schemaLanguage)
-    .enablePlugins(SbtTwirl)
-    .disablePlugins(bintray.BintrayPlugin)
+  lazy val scalaGenerator =
+    Project(id = "scala-generator", base = scalaDir / "generator")
+      .dependsOn(scalaRuntime, generatorApi, schemaLanguage)
+      .enablePlugins(SbtTwirl)
+      .disablePlugins(bintray.BintrayPlugin)
 
-  lazy val scalaRuntime = Project(id = "scala-runtime", base = scalaDir / "runtime")
-    .disablePlugins(bintray.BintrayPlugin)
+  lazy val scalaRuntime =
+    Project(id = "scala-runtime", base = scalaDir / "runtime")
+      .disablePlugins(bintray.BintrayPlugin)
 
-  lazy val testLib = Project(
-    id = "scala-test-lib", base = scalaDir / "test-lib")
-    .dependsOn(scalaGenerator)
-    .disablePlugins(bintray.BintrayPlugin)
+  lazy val testLib =
+    Project(id = "scala-test-lib", base = scalaDir / "test-lib")
+      .dependsOn(scalaGenerator)
+      .disablePlugins(bintray.BintrayPlugin)
 
-  lazy val scalaGeneratorTest = Project(
-    id = "scala-generator-test", base = scalaDir / "generator-test")
-    .dependsOn(scalaGenerator)
-    .dependsOn(testLib)
-    .disablePlugins(bintray.BintrayPlugin)
+  lazy val scalaGeneratorTestGenerator =
+    Project(id = "scala-generator-test-generator", base = scalaDir / "generator-test-generator")
+      .dependsOn(scalaGenerator)
 
-  lazy val scalaFixture = Project(
-    id = "scala-fixture", base = scalaDir / "fixture")
-    .dependsOn(scalaGenerator)
-    .disablePlugins(bintray.BintrayPlugin)
+  lazy val scalaGeneratorTest =
+    Project(id = "scala-generator-test", base = scalaDir / "generator-test")
+      .dependsOn(scalaGenerator)
+      .dependsOn(testLib)
+      .dependsOn(scalaGeneratorTestGenerator)
+      .disablePlugins(bintray.BintrayPlugin)
 
-  lazy val scalaFixtureTest = Project(
-    id = "scala-fixture-test", base = scalaDir / "fixture-test")
-    .dependsOn(scalaGenerator)
-    .dependsOn(scalaFixture)
-    .dependsOn(testLib)
-    .disablePlugins(bintray.BintrayPlugin)
+  lazy val scalaFixture =
+    Project(id = "scala-fixture", base = scalaDir / "fixture")
+      .dependsOn(scalaGenerator)
+      .disablePlugins(bintray.BintrayPlugin)
+
+  lazy val scalaFixtureTest =
+    Project(id = "scala-fixture-test", base = scalaDir / "fixture-test")
+      .dependsOn(scalaGenerator)
+      .dependsOn(scalaFixture)
+      .dependsOn(testLib)
+      .disablePlugins(bintray.BintrayPlugin)
 
   private[this] val javaDir = file("java")
 
-  lazy val javaGenerator = Project(id = "java-generator", base = javaDir / "generator")
-    .dependsOn(generatorApi)
-    .disablePlugins(bintray.BintrayPlugin)
+  lazy val javaGenerator =
+    Project(id = "java-generator", base = javaDir / "generator")
+      .dependsOn(generatorApi)
+      .disablePlugins(bintray.BintrayPlugin)
 
-  lazy val javaGeneratorTest = Project(
-    id = "java-generator-test", base = javaDir / "generator-test")
-    .dependsOn(javaGenerator)
-    .disablePlugins(bintray.BintrayPlugin)
+  lazy val javaGeneratorTest =
+    Project(id = "java-generator-test", base = javaDir / "generator-test")
+      .dependsOn(javaGenerator)
+      .disablePlugins(bintray.BintrayPlugin)
 
-  lazy val javaRuntime = Project(id = "java-runtime", base = javaDir / "runtime")
-    .disablePlugins(bintray.BintrayPlugin)
+  lazy val javaRuntime =
+    Project(id = "java-runtime", base = javaDir / "runtime")
+      .disablePlugins(bintray.BintrayPlugin)
 
   private[this] val androidDir = file("android")
 
-  lazy val androidGenerator = Project(id = "android-generator", base = androidDir / "generator")
-    .dependsOn(generatorApi)
-    .disablePlugins(bintray.BintrayPlugin)
+  lazy val androidGenerator =
+    Project(id = "android-generator", base = androidDir / "generator")
+      .dependsOn(generatorApi)
+      .disablePlugins(bintray.BintrayPlugin)
 
-  lazy val androidGeneratorTest = Project(
-    id = "android-generator-test", base = androidDir / "generator-test")
-    .dependsOn(androidGenerator, androidRuntime)
-    .disablePlugins(bintray.BintrayPlugin)
+  lazy val androidGeneratorTest =
+    Project(id = "android-generator-test", base = androidDir / "generator-test")
+      .dependsOn(androidGenerator, androidRuntime)
+      .disablePlugins(bintray.BintrayPlugin)
 
-  lazy val androidRuntime = Project(id = "android-runtime", base = androidDir / "runtime")
-    .disablePlugins(bintray.BintrayPlugin)
+  lazy val androidRuntime =
+    Project(id = "android-runtime", base = androidDir / "runtime")
+      .disablePlugins(bintray.BintrayPlugin)
 
   private[this] val swiftDir = file("swift")
-  lazy val swiftGenerator = Project(id = "swift-generator", base = swiftDir / "generator")
-    .dependsOn(generatorApi)
-    .disablePlugins(bintray.BintrayPlugin)
+  lazy val swiftGenerator =
+    Project(id = "swift-generator", base = swiftDir / "generator")
+      .dependsOn(generatorApi)
+      .disablePlugins(bintray.BintrayPlugin)
 
   private[this] val typescriptLiteDir = file("typescript-lite")
-  lazy val typescriptLiteGenerator = Project(id = "typescript-lite-generator", base = typescriptLiteDir / "generator")
-    .dependsOn(generatorApi)
-    .disablePlugins(bintray.BintrayPlugin)
+  lazy val typescriptLiteGenerator =
+    Project(id = "typescript-lite-generator",
+            base = typescriptLiteDir / "generator")
+      .dependsOn(generatorApi)
+      .disablePlugins(bintray.BintrayPlugin)
 
   lazy val cli = Project(id = "courier-cli", base = file("cli"))
     .dependsOn(
@@ -179,17 +199,20 @@ object Courier extends Build with OverridablePublishSettings {
       scalaGenerator,
       typescriptLiteGenerator,
       swiftGenerator
-    ).aggregate(
+    )
+    .aggregate(
       javaGenerator,
       androidGenerator,
       scalaGenerator,
       typescriptLiteGenerator,
       swiftGenerator
-    ).settings(
+    )
+    .settings(
       executableFile := {
         val exeFile = target.value / "courier"
         print(s"Writing executable file '$exeFile'...")
-        IO.write(exeFile, """#!/bin/bash
+        IO.write(exeFile,
+                 """#!/bin/bash
                             |exec java -jar $0 "$@"
                             |
                             |""".stripMargin)
@@ -198,16 +221,19 @@ object Courier extends Build with OverridablePublishSettings {
         println("written.")
         exeFile
       }
-  ).disablePlugins(bintray.BintrayPlugin)
-
-  lazy val typescriptLiteGeneratorTest = Project(
-    id = "typescript-lite-generator-test", base = typescriptLiteDir / "generator-test")
-    .dependsOn(typescriptLiteGenerator)
+    )
     .disablePlugins(bintray.BintrayPlugin)
 
-  lazy val courierSbtPlugin = Project(id = "sbt-plugin", base = file("sbt-plugin"))
-    .dependsOn(scalaGenerator)
-    .disablePlugins(xerial.sbt.Sonatype)
+  lazy val typescriptLiteGeneratorTest =
+    Project(id = "typescript-lite-generator-test",
+            base = typescriptLiteDir / "generator-test")
+      .dependsOn(typescriptLiteGenerator)
+      .disablePlugins(bintray.BintrayPlugin)
+
+  lazy val courierSbtPlugin =
+    Project(id = "sbt-plugin", base = file("sbt-plugin"))
+      .dependsOn(scalaGenerator)
+      .disablePlugins(xerial.sbt.Sonatype)
 
   //
   // Publishing
@@ -227,27 +253,30 @@ object Courier extends Build with OverridablePublishSettings {
   // Until then we have to be very explicit about publishing exactly what we want, mainly
   // to avoid build failures that would happen if we tried to publish the sbt plugin with scala
   // 2.11.
-  def publishCommands(publishCommand: String, sbtPluginCommand: Option[String] = None) = {
+  def publishCommands(publishCommand: String,
+                      sbtPluginCommand: Option[String] = None) = {
     // We do not cross build java projects:
     val baseCommand = s";project schema-language;$publishCommand" +
-    s";project generator-api;$publishCommand" +
-    s";project java-generator;$publishCommand" +
-    s";project java-runtime;$publishCommand" +
-    s";project android-generator;$publishCommand" +
-    s";project android-runtime;$publishCommand" +
-    s";project swift-generator;$publishCommand" +
-    s";project typescript-lite-generator;$publishCommand" +
-    s";++$sbtScalaVersion;project scala-generator;$publishCommand" +
-    s";++$currentScalaVersion;project scala-generator;$publishCommand" +
-    s";++$sbtScalaVersion;project scala-runtime;$publishCommand" +
-    s";++$currentScalaVersion;project scala-runtime;$publishCommand" +
-    s";++$sbtScalaVersion;project scala-fixture;$publishCommand" +
-    s";++$currentScalaVersion;project scala-fixture;$publishCommand"
-    sbtPluginCommand.map { sbtPluginCommand =>
-      baseCommand + s";++$sbtScalaVersion;project sbt-plugin;$sbtPluginCommand"
-    }.getOrElse {
-      baseCommand
-    }
+      s";project generator-api;$publishCommand" +
+      s";project java-generator;$publishCommand" +
+      s";project java-runtime;$publishCommand" +
+      s";project android-generator;$publishCommand" +
+      s";project android-runtime;$publishCommand" +
+      s";project swift-generator;$publishCommand" +
+      s";project typescript-lite-generator;$publishCommand" +
+      s";++$sbtScalaVersion;project scala-generator;$publishCommand" +
+      s";++$currentScalaVersion;project scala-generator;$publishCommand" +
+      s";++$sbtScalaVersion;project scala-runtime;$publishCommand" +
+      s";++$currentScalaVersion;project scala-runtime;$publishCommand" +
+      s";++$sbtScalaVersion;project scala-fixture;$publishCommand" +
+      s";++$currentScalaVersion;project scala-fixture;$publishCommand"
+    sbtPluginCommand
+      .map { sbtPluginCommand =>
+        baseCommand + s";++$sbtScalaVersion;project sbt-plugin;$sbtPluginCommand"
+      }
+      .getOrElse {
+        baseCommand
+      }
   }
 
   lazy val root = Project(id = "courier", base = file("."))
@@ -266,18 +295,23 @@ object Courier extends Build with OverridablePublishSettings {
       swiftGenerator,
       typescriptLiteGenerator,
       typescriptLiteGeneratorTest,
-      cli)
+      cli
+    )
     .settings(runtimeVersionSettings)
     .settings(packagedArtifacts := Map.empty) // disable publish for root aggregate module
     .settings(
       // scripted attempts to publish what it needs, but because of the above mentioned cross
       // build issues, we have to manually publish what we need before we test here
-      addCommandAlias(s"fulltest", s";compile;test;fullpublish-ivylocal;" +
-                      s"project courier;++$sbtScalaVersion;scripted"),
+      addCommandAlias(s"fulltest",
+                      s";compile;test;fullpublish-ivylocal;" +
+                        s"project courier;++$sbtScalaVersion;scripted"),
       addCommandAlias("fullpublish", publishCommands("publish")),
-      addCommandAlias("fullpublish-signed", publishCommands("publish-signed", Some("publish"))),
-      addCommandAlias("fullpublish-ivylocal", publishCommands("publish-local", Some("publish-local"))),
-      addCommandAlias("fullpublish-mavenlocal", publishCommands("publishM2")))
+      addCommandAlias("fullpublish-signed",
+                      publishCommands("publish-signed", Some("publish"))),
+      addCommandAlias("fullpublish-ivylocal",
+                      publishCommands("publish-local", Some("publish-local"))),
+      addCommandAlias("fullpublish-mavenlocal", publishCommands("publishM2"))
+    )
 
   //
   // Dependencies
@@ -290,21 +324,23 @@ object Courier extends Build with OverridablePublishSettings {
       val data = "com.linkedin.pegasus" % "data" % version
       val dataAvro = "com.linkedin.pegasus" % s"data-avro-$avroVersion" % version
       val generator = ("com.linkedin.pegasus" % "generator" % version)
-        // Only used by the java code generator, which we do not use.
+      // Only used by the java code generator, which we do not use.
         .exclude("com.linkedin.pegasus", "r2-core")
-        //.exclude("com.sun.codemodel", "codemodel")
+      //.exclude("com.sun.codemodel", "codemodel")
     }
 
     object ScalaParserCombinators {
       val version = "1.0.4"
 
       // this is part of scala-library in 2.10 and earlier
-      def dependencies(scalaVersion: String) = CrossVersion.partialVersion(scalaVersion) match {
-        case Some((2, scalaMajor)) if scalaMajor > 10 =>
-          Seq("org.scala-lang.modules" %% "scala-parser-combinators" % version)
-        case _ =>
-          Seq.empty[ModuleID]
-      }
+      def dependencies(scalaVersion: String) =
+        CrossVersion.partialVersion(scalaVersion) match {
+          case Some((2, scalaMajor)) if scalaMajor > 10 =>
+            Seq(
+              "org.scala-lang.modules" %% "scala-parser-combinators" % version)
+          case _ =>
+            Seq.empty[ModuleID]
+        }
     }
 
     object JUnit {
@@ -371,14 +407,15 @@ object Courier extends Build with OverridablePublishSettings {
 
   // In order to be able to quickly test our generator, we use
   // this approach, which has has been taken directly from Sleipnir by Dmitriy Yefremov.
-  lazy val forkedVmCourierGenerator = taskKey[Seq[File]](
-    "Courier generator executed in a forked VM")
+  lazy val forkedVmCourierGenerator =
+    taskKey[Seq[File]]("Courier generator executed in a forked VM")
   lazy val forkedVmCourierDest = settingKey[File]("Generator target directory")
 
-  lazy val forkedVmCourierMainClass = settingKey[String]("Main Generator class to execute.")
+  lazy val forkedVmCourierMainClass =
+    settingKey[String]("Main Generator class to execute.")
 
-  lazy val forkedVmCourierClasspath = taskKey[Seq[File]](
-    "Classpath to use when running the generator.")
+  lazy val forkedVmCourierClasspath =
+    taskKey[Seq[File]]("Classpath to use when running the generator.")
 
   lazy val forkedVmSourceDirectory =
     settingKey[File]("directory containing .courier and .pdsc files")
@@ -387,7 +424,6 @@ object Courier extends Build with OverridablePublishSettings {
     settingKey[Seq[String]]("Additional args to pass to the generator")
 
   val forkedVmCourierGeneratorSettings = Seq(
-
     // TODO: for android and swift, don't generate into a scala-x.xx dir
     forkedVmCourierGenerator in Compile := {
       val mainClass = forkedVmCourierMainClass.value
@@ -395,10 +431,16 @@ object Courier extends Build with OverridablePublishSettings {
       val dst = forkedVmCourierDest.value
       val classpath = forkedVmCourierClasspath.value
       val additionalArgs = forkedVmAdditionalArgs.value
-      streams.value.log.info("Generating courier bindings...")
+      streams.value.log.info(s"Generating courier bindings for files in $src...")
       val files =
-        runForkedGenerator(mainClass, src, dst, classpath, additionalArgs, streams.value.log)
-      streams.value.log.info(s"${files.size} classes generated from $src for $mainClass")
+        runForkedGenerator(mainClass,
+                           src,
+                           dst,
+                           classpath,
+                           additionalArgs,
+                           streams.value.log)
+      streams.value.log
+        .info(s"${files.size} classes generated from $src for $mainClass")
       files
     },
     forkedVmAdditionalArgs := Seq(),
@@ -410,25 +452,25 @@ object Courier extends Build with OverridablePublishSettings {
     cleanFiles += target.value / s"scala-${scalaBinaryVersion.value}" / "courier"
   )
 
-  def runForkedGenerator(
-      mainClass: String,
-      src: File,
-      dst: File,
-      classpath: Seq[File],
-      additionalArgs: Seq[String],
-      log: Logger): Seq[File] = {
+  def runForkedGenerator(mainClass: String,
+                         src: File,
+                         dst: File,
+                         classpath: Seq[File],
+                         additionalArgs: Seq[String],
+                         log: Logger): Seq[File] = {
     IO.withTemporaryFile("courier", "output") { tmpFile =>
       val outStream = new java.io.FileOutputStream(tmpFile)
       try {
         val args = Seq(dst.toString, src.toString, src.toString) ++ additionalArgs
         val exitValue =
-          Fork.java(
-            None,
-            "-cp" +: classpath.map(_.getAbsolutePath).mkString(java.io.File.pathSeparator) +:
-              mainClass +:
-              args,
-            None,
-            CustomOutput(outStream))
+          Fork.java(None,
+                    "-cp" +: classpath
+                      .map(_.getAbsolutePath)
+                      .mkString(java.io.File.pathSeparator) +:
+                      mainClass +:
+                      args,
+                    None,
+                    CustomOutput(outStream))
         val outputLines = scala.io.Source.fromFile(tmpFile).getLines().toSeq
         if (exitValue != 0) {
           outputLines.foreach(println)
@@ -445,5 +487,6 @@ object Courier extends Build with OverridablePublishSettings {
   //
   // Other Commands
   //
-  lazy val executableFile = taskKey[File]("Distributes the current version as an executable at cli/target/courier")
+  lazy val executableFile = taskKey[File](
+    "Distributes the current version as an executable at cli/target/courier")
 }

--- a/sbt-plugin/src/main/scala/org/coursera/courier/sbt/CourierPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/coursera/courier/sbt/CourierPlugin.scala
@@ -19,7 +19,7 @@ package org.coursera.courier.sbt
 import java.io.File.pathSeparator
 
 import org.apache.commons.lang3.exception.ExceptionUtils
-import org.coursera.courier.ScalaGenerator
+import org.coursera.courier.DefaultScalaGenerator
 import org.coursera.courier.api.DefaultGeneratorRunner
 import org.coursera.courier.api.GeneratorRunnerOptions
 import org.coursera.courier.api.ParserForFileFormat
@@ -99,7 +99,7 @@ object CourierPlugin extends Plugin {
 
   private def courierSettings(conf: Configuration): Seq[Def.Setting[_]] = Seq(
 
-    courierGeneratorClass in conf := classOf[ScalaGenerator],
+    courierGeneratorClass in conf := classOf[DefaultScalaGenerator],
 
     courierSourceDirectory in conf := (sourceDirectory in conf).value / "pegasus",
 

--- a/sbt-plugin/src/main/scala/org/coursera/courier/sbt/CourierPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/coursera/courier/sbt/CourierPlugin.scala
@@ -19,7 +19,7 @@ package org.coursera.courier.sbt
 import java.io.File.pathSeparator
 
 import org.apache.commons.lang3.exception.ExceptionUtils
-import org.coursera.courier.DefaultScalaGenerator
+import org.coursera.courier.ScalaGenerator
 import org.coursera.courier.api.DefaultGeneratorRunner
 import org.coursera.courier.api.GeneratorRunnerOptions
 import org.coursera.courier.api.ParserForFileFormat
@@ -99,7 +99,7 @@ object CourierPlugin extends Plugin {
 
   private def courierSettings(conf: Configuration): Seq[Def.Setting[_]] = Seq(
 
-    courierGeneratorClass in conf := classOf[DefaultScalaGenerator],
+    courierGeneratorClass in conf := classOf[ScalaGenerator],
 
     courierSourceDirectory in conf := (sourceDirectory in conf).value / "pegasus",
 

--- a/scala/generator-test-generator/build.sbt
+++ b/scala/generator-test-generator/build.sbt
@@ -1,0 +1,5 @@
+// Minimal library to define generator with testable mixin behavior.
+
+name := "courier-generator-test-genertor"
+
+packagedArtifacts := Map.empty // do not publish

--- a/scala/generator-test-generator/src/main/scala/org/coursera/courier/generator/TestDataTemplateGenerator.scala
+++ b/scala/generator-test-generator/src/main/scala/org/coursera/courier/generator/TestDataTemplateGenerator.scala
@@ -1,0 +1,48 @@
+/*
+ Copyright 2015 Coursera Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package org.coursera.courier.generator
+
+import org.coursera.courier.generator.specs.Definition
+
+import scala.collection.immutable
+
+/**
+ * Adds a type-dependent method to each class and companion object:
+ *
+ * class Foo {
+ *   ...
+ *   def classMixinDef: Option[Foo] = None
+ * }
+ *
+ * object Foo {
+ *    ...
+ *    def companionMixinDef: Option[Foo] = None
+ * }
+ * 
+ * Templates with these methods will compile, and mixin method presence
+ * can be verified in generator unit tests.
+ */
+object TestGeneratorMixin extends GeneratorMixin {
+  override def extraClassExpressions(
+      definition: Definition): immutable.Seq[String] =
+    List(s"def classMixinDef: Option[${definition.dataType}] = None")
+  override def extraCompanionExpressions(
+      definition: Definition): immutable.Seq[String] =
+    List(s"def companionMixinDef: Option[${definition.dataType}] = None")
+}
+
+object TestScalaDataTemplateGenerator extends AbstractScalaDataTemplateGenerator(TestGeneratorMixin)

--- a/scala/generator-test/build.sbt
+++ b/scala/generator-test/build.sbt
@@ -17,9 +17,9 @@ javaOptions in Test +=
 // Test generator
 forkedVmCourierGeneratorSettings
 
-forkedVmCourierMainClass := "org.coursera.courier.generator.ScalaDataTemplateGenerator"
+forkedVmCourierMainClass := "org.coursera.courier.generator.TestScalaDataTemplateGenerator"
 
-forkedVmCourierClasspath := (dependencyClasspath in Runtime in scalaGenerator).value.files
+forkedVmCourierClasspath := (dependencyClasspath in Runtime in scalaGeneratorTestGenerator).value.files
 
 forkedVmSourceDirectory := (sourceDirectory in referenceSuite).value / "main" / "courier"
 forkedVmSourceDirectory := (sourceDirectory in testLib).value / "main" / "scala"

--- a/scala/generator-test/src/test/scala/org/coursera/courier/generator/EnumGeneratorTest.scala
+++ b/scala/generator-test/src/test/scala/org/coursera/courier/generator/EnumGeneratorTest.scala
@@ -18,6 +18,7 @@ package org.coursera.courier.generator
 
 import org.coursera.enums.EnumProperties
 import org.coursera.enums.Fruits
+import org.coursera.records.test.SimpleMapMap
 import org.junit.Test
 
 class EnumGeneratorTest extends GeneratorTest with SchemaFixtures {
@@ -50,4 +51,11 @@ class EnumGeneratorTest extends GeneratorTest with SchemaFixtures {
 
     assert(toColor(EnumProperties.BANANA) === "yellow")
   }
+
+  @Test
+  def testMixins(): Unit = {
+    val classMixin: Option[EnumProperties] = EnumProperties.BANANA.classMixinDef
+    val companionMixin: Option[EnumProperties] = EnumProperties.companionMixinDef
+  }
+
 }

--- a/scala/generator-test/src/test/scala/org/coursera/courier/generator/MapGeneratorTest.scala
+++ b/scala/generator-test/src/test/scala/org/coursera/courier/generator/MapGeneratorTest.scala
@@ -177,4 +177,10 @@ class MapGeneratorTest extends GeneratorTest with SchemaFixtures {
     val roundTripped = SimpleMapMap.build(roundTrip(original.data()), DataConversion.SetReadOnly)
     assert(original === roundTripped)
   }
+
+  @Test
+  def testMixins(): Unit = {
+    val classMixin: Option[SimpleMapMap] = SimpleMapMap().classMixinDef
+    val companionMixin: Option[SimpleMapMap] = SimpleMapMap.companionMixinDef
+  }
 }

--- a/scala/generator-test/src/test/scala/org/coursera/courier/generator/RecordGeneratorTest.scala
+++ b/scala/generator-test/src/test/scala/org/coursera/courier/generator/RecordGeneratorTest.scala
@@ -47,15 +47,18 @@ import org.junit.Test
 
 class RecordGeneratorTest extends GeneratorTest with SchemaFixtures {
 
-
-  private val primitiveRecordFieldsJson = load("WithPrimitives_flex_defaults.json")
+  private val primitiveRecordFieldsJson = load(
+    "WithPrimitives_flex_defaults.json")
 
   @Test
   def testWithPrimitives(): Unit = {
-    val original = WithPrimitives(1, 3000000000L, 3.3f, 4.4e38d, true, "str", bytes1)
-    val roundTripped = WithPrimitives.build(roundTrip(original.data()), DataConversion.SetReadOnly)
+    val original =
+      WithPrimitives(1, 3000000000L, 3.3f, 4.4e38d, true, "str", bytes1)
+    val roundTripped = WithPrimitives.build(roundTrip(original.data()),
+                                            DataConversion.SetReadOnly)
     val WithPrimitives(int, long, float, double, boolean, string, b) = original
-    val reconstructed = WithPrimitives(int, long, float, double, boolean, string, b)
+    val reconstructed =
+      WithPrimitives(int, long, float, double, boolean, string, b)
 
     assert(original === roundTripped)
     assert(original === reconstructed)
@@ -75,12 +78,19 @@ class RecordGeneratorTest extends GeneratorTest with SchemaFixtures {
 
   @Test
   def testWithOptionalPrimitives_Some(): Unit = {
-    val original = WithOptionalPrimitives(
-      Some(1), Some(3000000000L), Some(3.3f), Some(4.4e38d), Some(true), Some("str"), Some(bytes1))
-    val roundTripped = WithOptionalPrimitives.build(
-      roundTrip(original.data()), DataConversion.SetReadOnly)
-    val WithOptionalPrimitives(int, long, float, double, boolean, string, b) = original
-    val reconstructed = WithOptionalPrimitives(int, long, float, double, boolean, string, b)
+    val original = WithOptionalPrimitives(Some(1),
+                                          Some(3000000000L),
+                                          Some(3.3f),
+                                          Some(4.4e38d),
+                                          Some(true),
+                                          Some("str"),
+                                          Some(bytes1))
+    val roundTripped = WithOptionalPrimitives.build(roundTrip(original.data()),
+                                                    DataConversion.SetReadOnly)
+    val WithOptionalPrimitives(int, long, float, double, boolean, string, b) =
+      original
+    val reconstructed =
+      WithOptionalPrimitives(int, long, float, double, boolean, string, b)
 
     assert(original === roundTripped)
     assert(original === reconstructed)
@@ -105,11 +115,14 @@ class RecordGeneratorTest extends GeneratorTest with SchemaFixtures {
 
   @Test
   def testWithOptionalPrimitives_None(): Unit = {
-    val original = WithOptionalPrimitives(None, None, None, None, None, None, None)
-    val roundTripped = WithOptionalPrimitives.build(
-      roundTrip(original.data()), DataConversion.SetReadOnly)
-    val WithOptionalPrimitives(int, long, float, double, boolean, string, b) = original
-    val reconstructed = WithOptionalPrimitives(int, long, float, double, boolean, string, b)
+    val original =
+      WithOptionalPrimitives(None, None, None, None, None, None, None)
+    val roundTripped = WithOptionalPrimitives.build(roundTrip(original.data()),
+                                                    DataConversion.SetReadOnly)
+    val WithOptionalPrimitives(int, long, float, double, boolean, string, b) =
+      original
+    val reconstructed =
+      WithOptionalPrimitives(int, long, float, double, boolean, string, b)
 
     assert(original === roundTripped)
     assert(original === reconstructed)
@@ -134,11 +147,14 @@ class RecordGeneratorTest extends GeneratorTest with SchemaFixtures {
 
   @Test
   def testWithPrimitiveTyperefs(): Unit = {
-    val original = WithPrimitiveTyperefs(1, 3000000000L, 3.3f, 4.4e38d, true, "str", bytes1)
-    val roundTripped = WithPrimitiveTyperefs.build(
-      roundTrip(original.data()), DataConversion.SetReadOnly)
-    val WithPrimitiveTyperefs(int, long, float, double, boolean, string, b) = original
-    val reconstructed = WithPrimitiveTyperefs(int, long, float, double, boolean, string, b)
+    val original =
+      WithPrimitiveTyperefs(1, 3000000000L, 3.3f, 4.4e38d, true, "str", bytes1)
+    val roundTripped = WithPrimitiveTyperefs.build(roundTrip(original.data()),
+                                                   DataConversion.SetReadOnly)
+    val WithPrimitiveTyperefs(int, long, float, double, boolean, string, b) =
+      original
+    val reconstructed =
+      WithPrimitiveTyperefs(int, long, float, double, boolean, string, b)
 
     assert(original === roundTripped)
     assert(original === reconstructed)
@@ -158,13 +174,30 @@ class RecordGeneratorTest extends GeneratorTest with SchemaFixtures {
 
   @Test
   def testWithOptionalPrimitiveTyperefs_Some(): Unit = {
-    val original = WithOptionalPrimitiveTyperefs(
-      Some(1), Some(3000000000L), Some(3.3f), Some(4.4e38d), Some(true), Some("str"),
-      Some(bytes1))
+    val original = WithOptionalPrimitiveTyperefs(Some(1),
+                                                 Some(3000000000L),
+                                                 Some(3.3f),
+                                                 Some(4.4e38d),
+                                                 Some(true),
+                                                 Some("str"),
+                                                 Some(bytes1))
     val roundTripped = WithOptionalPrimitiveTyperefs.build(
-      roundTrip(original.data()), DataConversion.SetReadOnly)
-    val WithOptionalPrimitiveTyperefs(int, long, float, double, boolean, string, b) = original
-    val reconstructed = WithOptionalPrimitiveTyperefs(int, long, float, double, boolean, string, b)
+      roundTrip(original.data()),
+      DataConversion.SetReadOnly)
+    val WithOptionalPrimitiveTyperefs(int,
+                                      long,
+                                      float,
+                                      double,
+                                      boolean,
+                                      string,
+                                      b) = original
+    val reconstructed = WithOptionalPrimitiveTyperefs(int,
+                                                      long,
+                                                      float,
+                                                      double,
+                                                      boolean,
+                                                      string,
+                                                      b)
 
     assert(original === roundTripped)
     assert(original === reconstructed)
@@ -189,11 +222,25 @@ class RecordGeneratorTest extends GeneratorTest with SchemaFixtures {
 
   @Test
   def testWithOptionalPrimitiveTyperefs_None(): Unit = {
-    val original = WithOptionalPrimitiveTyperefs(None, None, None, None, None, None, None)
+    val original =
+      WithOptionalPrimitiveTyperefs(None, None, None, None, None, None, None)
     val roundTripped = WithOptionalPrimitiveTyperefs.build(
-      roundTrip(original.data()), DataConversion.SetReadOnly)
-    val WithOptionalPrimitiveTyperefs(int, long, float, double, boolean, string, b) = original
-    val reconstructed = WithOptionalPrimitiveTyperefs(int, long, float, double, boolean, string, b)
+      roundTrip(original.data()),
+      DataConversion.SetReadOnly)
+    val WithOptionalPrimitiveTyperefs(int,
+                                      long,
+                                      float,
+                                      double,
+                                      boolean,
+                                      string,
+                                      b) = original
+    val reconstructed = WithOptionalPrimitiveTyperefs(int,
+                                                      long,
+                                                      float,
+                                                      double,
+                                                      boolean,
+                                                      string,
+                                                      b)
 
     assert(original === roundTripped)
     assert(original === reconstructed)
@@ -219,7 +266,8 @@ class RecordGeneratorTest extends GeneratorTest with SchemaFixtures {
   def testWithPrimitiveCustomTypes(): Unit = {
     val original = WithPrimitiveCustomTypes(CustomInt(1))
     val roundTripped = WithPrimitiveCustomTypes.build(
-      roundTrip(original.data()), DataConversion.SetReadOnly)
+      roundTrip(original.data()),
+      DataConversion.SetReadOnly)
     val WithPrimitiveCustomTypes(customInt) = original
     val reconstructed = WithPrimitiveCustomTypes(customInt)
 
@@ -240,7 +288,8 @@ class RecordGeneratorTest extends GeneratorTest with SchemaFixtures {
   def testWithOptionalPrimitiveCustomTypes(): Unit = {
     val original = WithOptionalPrimitiveCustomTypes(Some(CustomInt(1)))
     val roundTripped = WithOptionalPrimitiveCustomTypes.build(
-      roundTrip(original.data()), DataConversion.SetReadOnly)
+      roundTrip(original.data()),
+      DataConversion.SetReadOnly)
     val WithOptionalPrimitiveCustomTypes(Some(customInt)) = original
     val reconstructed = WithOptionalPrimitiveCustomTypes(Some(customInt))
 
@@ -258,7 +307,8 @@ class RecordGeneratorTest extends GeneratorTest with SchemaFixtures {
   @Test
   def testWithInclude(): Unit = {
     val original = WithInclude(Some("message"), 1)
-    val roundTripped = WithInclude.build(roundTrip(original.data()), DataConversion.SetReadOnly)
+    val roundTripped =
+      WithInclude.build(roundTrip(original.data()), DataConversion.SetReadOnly)
     val WithInclude(Some(message), int) = original
     val reconstructed = WithInclude(Some(message), int)
 
@@ -277,11 +327,14 @@ class RecordGeneratorTest extends GeneratorTest with SchemaFixtures {
 
   @Test
   def testWithInlineRecord_Some(): Unit = {
-    val original = WithInlineRecord(InlineRecord(1), Some(InlineOptionalRecord("str")))
-    val roundTripped = WithInlineRecord.build(
-      roundTrip(original.data()), DataConversion.SetReadOnly)
-    val WithInlineRecord(InlineRecord(int), Some(InlineOptionalRecord(string))) = original
-    val reconstructed = WithInlineRecord(InlineRecord(int), Some(InlineOptionalRecord(string)))
+    val original =
+      WithInlineRecord(InlineRecord(1), Some(InlineOptionalRecord("str")))
+    val roundTripped = WithInlineRecord.build(roundTrip(original.data()),
+                                              DataConversion.SetReadOnly)
+    val WithInlineRecord(InlineRecord(int),
+                         Some(InlineOptionalRecord(string))) = original
+    val reconstructed =
+      WithInlineRecord(InlineRecord(int), Some(InlineOptionalRecord(string)))
 
     assert(original === roundTripped)
     assert(original === reconstructed)
@@ -290,7 +343,8 @@ class RecordGeneratorTest extends GeneratorTest with SchemaFixtures {
       assert(records.inline.value === 1)
       assert(records.inlineOptional.get.value === "str")
 
-      val copy = records.copy(inlineOptional = Some(InlineOptionalRecord("copy")))
+      val copy =
+        records.copy(inlineOptional = Some(InlineOptionalRecord("copy")))
       assert(copy.inline.value === 1)
       assert(copy.inlineOptional.get.value === "copy")
     }
@@ -299,8 +353,8 @@ class RecordGeneratorTest extends GeneratorTest with SchemaFixtures {
   @Test
   def testWithInlineRecord_None(): Unit = {
     val original = WithInlineRecord(InlineRecord(1), None)
-    val roundTripped = WithInlineRecord.build(
-      roundTrip(original.data()), DataConversion.SetReadOnly)
+    val roundTripped = WithInlineRecord.build(roundTrip(original.data()),
+                                              DataConversion.SetReadOnly)
     val WithInlineRecord(InlineRecord(int), None) = original
     val reconstructed = WithInlineRecord(InlineRecord(int), None)
 
@@ -315,18 +369,19 @@ class RecordGeneratorTest extends GeneratorTest with SchemaFixtures {
   @Test
   def testWithComplexTypes(): Unit = {
     import WithComplexTypes.Union
-    val original = WithComplexTypes(
-      Simple(Some("message")),
-      Fruits.APPLE,
-      Union.IntMember(1),
-      IntArray(1),
-      IntMap("a" -> 1),
-      SimpleMap("a" -> Simple(Some("message"))),
-      CustomInt(1))
-    val roundTripped = WithComplexTypes.build(
-      roundTrip(original.data()), DataConversion.SetReadOnly)
-    val WithComplexTypes(simple, fruit, union, array, map, complexMap, custom) = original
-    val reconstructed = WithComplexTypes(simple, fruit, union, array, map, complexMap, custom)
+    val original = WithComplexTypes(Simple(Some("message")),
+                                    Fruits.APPLE,
+                                    Union.IntMember(1),
+                                    IntArray(1),
+                                    IntMap("a" -> 1),
+                                    SimpleMap("a" -> Simple(Some("message"))),
+                                    CustomInt(1))
+    val roundTripped = WithComplexTypes.build(roundTrip(original.data()),
+                                              DataConversion.SetReadOnly)
+    val WithComplexTypes(simple, fruit, union, array, map, complexMap, custom) =
+      original
+    val reconstructed =
+      WithComplexTypes(simple, fruit, union, array, map, complexMap, custom)
 
     assert(original === roundTripped)
     assert(original === reconstructed)
@@ -342,18 +397,19 @@ class RecordGeneratorTest extends GeneratorTest with SchemaFixtures {
 
   @Test
   def testImplicitCollectionWrappers(): Unit = {
-    val original = WithComplexTypes(
-      Simple(Some("message")),
-      Fruits.APPLE,
-      1,
-      Seq(1),
-      Map("a" -> 1),
-      Map("a" -> Simple(Some("message"))),
-      CustomInt(1))
-    val roundTripped = WithComplexTypes.build(
-      roundTrip(original.data()), DataConversion.SetReadOnly)
-    val WithComplexTypes(simple, fruit, union, array, map, complexMap, custom) = original
-    val reconstructed = WithComplexTypes(simple, fruit, union, array, map, complexMap, custom)
+    val original = WithComplexTypes(Simple(Some("message")),
+                                    Fruits.APPLE,
+                                    1,
+                                    Seq(1),
+                                    Map("a" -> 1),
+                                    Map("a" -> Simple(Some("message"))),
+                                    CustomInt(1))
+    val roundTripped = WithComplexTypes.build(roundTrip(original.data()),
+                                              DataConversion.SetReadOnly)
+    val WithComplexTypes(simple, fruit, union, array, map, complexMap, custom) =
+      original
+    val reconstructed =
+      WithComplexTypes(simple, fruit, union, array, map, complexMap, custom)
 
     assert(original === roundTripped)
     assert(original === reconstructed)
@@ -438,8 +494,7 @@ class RecordGeneratorTest extends GeneratorTest with SchemaFixtures {
   @Test
   def testCopyDataTemplate(): Unit = {
     val original = WithOptionalComplexTypesDefaultNone(
-      record = Some(Simple(
-        message = Some("message"))))
+      record = Some(Simple(message = Some("message"))))
 
     val mutableData = original.data().copy()
     mutableData.getDataMap("record").put("message", "updated message")
@@ -469,5 +524,11 @@ class RecordGeneratorTest extends GeneratorTest with SchemaFixtures {
     // without its path, record.hashCode() will actually equal recordSameName.hashCode().
     // Fortunately, nothing should depend solely on hashCode() for determining whether two
     // records match.
+  }
+
+  @Test
+  def testMixins(): Unit = {
+    val classMixin: Option[Empty] = Empty().classMixinDef
+    val companionMixin: Option[Empty] = Empty.companionMixinDef
   }
 }

--- a/scala/generator-test/src/test/scala/org/coursera/courier/generator/TyperefGeneratorTest.scala
+++ b/scala/generator-test/src/test/scala/org/coursera/courier/generator/TyperefGeneratorTest.scala
@@ -24,13 +24,13 @@ import org.coursera.courier.generator.customtypes.CustomIntWrapper
 import org.coursera.courier.generator.customtypes.CustomMapTestKeyId
 import org.coursera.courier.generator.customtypes.CustomMapTestValueId
 import org.coursera.courier.generator.customtypes.CustomRecord
-import org.coursera.courier.generator.customtypes.CustomRecordCoercer
 import org.coursera.courier.generator.customtypes.CustomRecordTestId
 import org.coursera.courier.generator.customtypes.CustomUnionTestId
 import org.coursera.courier.templates.DataTemplates
 import org.coursera.courier.templates.DataTemplates.DataConversion
 import org.coursera.customtypes.CustomRecordArray
 import org.coursera.customtypes.CustomRecordToCustomRecordMap
+import org.coursera.enums.EnumProperties
 import org.coursera.enums.Fruits
 import org.coursera.maps.WithCustomMapTestIds
 import org.coursera.records.test.Empty
@@ -150,5 +150,11 @@ class TyperefGeneratorTest extends GeneratorTest with SchemaFixtures {
     val dataMap = DataTemplates.readDataMap(json)
     val wrapped = DataTemplateUtil.wrap(dataMap, classOf[WithCustomUnionTestId])
     assert(wrapped.union === CustomUnionTestIdMember(CustomUnionTestId(1)))
+  }
+
+  @Test
+  def testMixins(): Unit = {
+    val classMixin: Option[UnionTyperef] = UnionTyperef.IntMember(1).classMixinDef
+    val companionMixin: Option[UnionTyperef] = UnionTyperef.companionMixinDef
   }
 }

--- a/scala/generator-test/src/test/scala/org/coursera/courier/generator/UnionGeneratorTest.scala
+++ b/scala/generator-test/src/test/scala/org/coursera/courier/generator/UnionGeneratorTest.scala
@@ -19,7 +19,6 @@ package org.coursera.courier.generator
 import org.coursera.courier.templates.DataTemplates
 import DataTemplates.DataConversion
 import org.coursera.courier.generator.customtypes.CustomInt
-import org.coursera.courier.generator.customtypes.CustomIntCoercer
 import org.coursera.enums.Fruits
 import org.coursera.records.test.Empty
 import org.coursera.records.test.Simple
@@ -27,9 +26,9 @@ import org.coursera.records.test.SimpleArray
 import org.coursera.records.test.SimpleMap
 import org.coursera.typerefs.TypedDefinition
 import org.coursera.unions.WithComplexTypesUnion
+import org.coursera.unions.WithComplexTypesUnion.Union
 import org.coursera.unions.WithPrimitiveCustomTypesUnion
 import org.coursera.unions.WithPrimitivesUnion
-import org.junit.BeforeClass
 import org.junit.Test
 
 class UnionGeneratorTest extends GeneratorTest with SchemaFixtures {
@@ -154,5 +153,11 @@ class UnionGeneratorTest extends GeneratorTest with SchemaFixtures {
   @Test
   def testUnionTyperefSchema(): Unit = {
     assert(TypedDefinition.TYPEREF_SCHEMA.getDereferencedDataSchema === TypedDefinition.SCHEMA)
+  }
+
+  @Test
+  def testMixins(): Unit = {
+    val classMixin: Option[Union] = Union.EmptyMember(Empty()).classMixinDef
+    val companionMixin: Option[Union] = Union.companionMixinDef
   }
 }

--- a/scala/generator/src/main/scala/org/coursera/courier/ConfigurableScalaGenerator.scala
+++ b/scala/generator/src/main/scala/org/coursera/courier/ConfigurableScalaGenerator.scala
@@ -18,7 +18,6 @@ package org.coursera.courier
 
 import org.coursera.courier.generator.CourierPredef
 import org.coursera.courier.generator.GeneratorMixin
-import org.coursera.courier.generator.NilGeneratorMixin
 import org.coursera.courier.generator.ScalaCompilationUnit
 import org.coursera.courier.generator.ScalaGeneratedCode
 import org.coursera.courier.generator.TemplateGenerator
@@ -50,7 +49,7 @@ import scalariform.parser.ScalaParserException
 /**
  * Generates Scala files using the Twirl string template engine.
  */
-class ScalaGenerator(mixin: GeneratorMixin)
+class ConfigurableScalaGenerator(mixin: GeneratorMixin)
   extends TemplateGenerator {
 
   // TODO(jbetz): Make configurable

--- a/scala/generator/src/main/scala/org/coursera/courier/DefaultScalaGenerator.scala
+++ b/scala/generator/src/main/scala/org/coursera/courier/DefaultScalaGenerator.scala
@@ -1,0 +1,5 @@
+package org.coursera.courier
+
+import org.coursera.courier.generator.NilGeneratorMixin
+
+class DefaultScalaGenerator() extends ConfigurableScalaGenerator(NilGeneratorMixin)

--- a/scala/generator/src/main/scala/org/coursera/courier/ScalaGenerator.scala
+++ b/scala/generator/src/main/scala/org/coursera/courier/ScalaGenerator.scala
@@ -17,6 +17,8 @@
 package org.coursera.courier
 
 import org.coursera.courier.generator.CourierPredef
+import org.coursera.courier.generator.GeneratorMixin
+import org.coursera.courier.generator.NilGeneratorMixin
 import org.coursera.courier.generator.ScalaCompilationUnit
 import org.coursera.courier.generator.ScalaGeneratedCode
 import org.coursera.courier.generator.TemplateGenerator
@@ -48,7 +50,7 @@ import scalariform.parser.ScalaParserException
 /**
  * Generates Scala files using the Twirl string template engine.
  */
-class ScalaGenerator()
+class ScalaGenerator(mixin: GeneratorMixin)
   extends TemplateGenerator {
 
   // TODO(jbetz): Make configurable
@@ -60,18 +62,18 @@ class ScalaGenerator()
       case predef: Definition if CourierPredef.definitions.contains(predef) =>
         None // Predefined types should already exist, so we don't generate them
       case record: RecordDefinition =>
-        Some(RecordClass(record).body)
+        Some(RecordClass(record, mixin).body)
       case union: UnionDefinition =>
-        Some(UnionClass(union).body)
+        Some(UnionClass(union, mixin).body)
       case enum: EnumDefinition =>
-        Some(EnumClass(enum).body)
+        Some(EnumClass(enum, mixin).body)
       case array: ArrayDefinition =>
-        Some(ArrayClass(array).body)
+        Some(ArrayClass(array, mixin).body)
       case map: MapDefinition =>
-        Some(MapClass(map).body)
+        Some(MapClass(map, mixin).body)
       case typeref: TyperefDefinition =>
         if (generateTyperefs) {
-          Some(TyperefClass(typeref).body)
+          Some(TyperefClass(typeref, mixin).body)
         } else {
           None
         }
@@ -111,9 +113,9 @@ class ScalaGenerator()
     CourierPredef.bySchema.flatMap { case (schema, definition) =>
       val code = definition match {
         case array: ArrayDefinition =>
-          ArrayClass(array).body
+          ArrayClass(array, mixin).body
         case map: MapDefinition =>
-          MapClass(map).body
+          MapClass(map, mixin).body
         case _: Any =>
           throw new IllegalArgumentException(s"Unsupported schema type: ${schema.getClass}")
       }

--- a/scala/generator/src/main/scala/org/coursera/courier/ScalaGenerator.scala
+++ b/scala/generator/src/main/scala/org/coursera/courier/ScalaGenerator.scala
@@ -2,4 +2,4 @@ package org.coursera.courier
 
 import org.coursera.courier.generator.NilGeneratorMixin
 
-class DefaultScalaGenerator() extends ConfigurableScalaGenerator(NilGeneratorMixin)
+class ScalaGenerator() extends ConfigurableScalaGenerator(NilGeneratorMixin)

--- a/scala/generator/src/main/scala/org/coursera/courier/generator/AbstractScalaDataTemplateGenerator.scala
+++ b/scala/generator/src/main/scala/org/coursera/courier/generator/AbstractScalaDataTemplateGenerator.scala
@@ -1,0 +1,50 @@
+package org.coursera.courier.generator
+
+import com.linkedin.pegasus.generator.JavaCodeGeneratorBase
+import com.linkedin.pegasus.generator.PegasusDataTemplateGenerator
+import org.coursera.courier.ScalaGenerator
+import org.coursera.courier.api.DefaultGeneratorRunner
+import org.coursera.courier.api.GeneratorRunnerOptions
+
+import scala.collection.JavaConverters._
+
+/**
+ * Generates Scala data bindings classes from .pdsc schemas.
+ *
+ * Both the class and companion object hook into the extension points of rest.li-sbt-plugin.
+ */
+abstract class AbstractScalaDataTemplateGenerator(mixins: GeneratorMixin) {
+  def main(args: Array[String]) {
+    if (args.length != 3) {
+      println(
+        s"Usage: ${this.getClass.getName} " +
+          s"targetDirectoryPath resolverPath sourcePath1[:sourcePath2]+")
+      System.exit(1)
+    }
+    val targetDirectoryPath = args(0)
+    val resolverPath = args(1)
+    val sources = args(2).split(java.io.File.pathSeparator)
+    val generateImported =
+      Option(System.getProperty(PegasusDataTemplateGenerator.GENERATOR_GENERATE_IMPORTED))
+        .exists(_.toBoolean)
+    val defaultPackage = System.getProperty(JavaCodeGeneratorBase.GENERATOR_DEFAULT_PACKAGE)
+    val generateTyperefs = false
+    val generatePredef = false // set to true temporarily to manually generateRecord predef
+
+    val result = new DefaultGeneratorRunner().run(
+      new ScalaGenerator(mixins),
+      new GeneratorRunnerOptions(
+        targetDirectoryPath,
+        sources,
+        resolverPath)
+        .setDefaultPackage(defaultPackage)
+        .setDataNamespace(CourierPredef.dataNamespace)
+        .setGenerateImported(generateImported)
+        .setGenerateTyperefs(generateTyperefs)
+        .setGeneratePredef(generatePredef))
+
+    result.getTargetFiles.asScala.foreach { file =>
+      System.out.println(file.getAbsolutePath)
+    }
+  }
+}

--- a/scala/generator/src/main/scala/org/coursera/courier/generator/AbstractScalaDataTemplateGenerator.scala
+++ b/scala/generator/src/main/scala/org/coursera/courier/generator/AbstractScalaDataTemplateGenerator.scala
@@ -2,7 +2,7 @@ package org.coursera.courier.generator
 
 import com.linkedin.pegasus.generator.JavaCodeGeneratorBase
 import com.linkedin.pegasus.generator.PegasusDataTemplateGenerator
-import org.coursera.courier.ScalaGenerator
+import org.coursera.courier.ConfigurableScalaGenerator
 import org.coursera.courier.api.DefaultGeneratorRunner
 import org.coursera.courier.api.GeneratorRunnerOptions
 
@@ -32,7 +32,7 @@ abstract class AbstractScalaDataTemplateGenerator(mixins: GeneratorMixin) {
     val generatePredef = false // set to true temporarily to manually generateRecord predef
 
     val result = new DefaultGeneratorRunner().run(
-      new ScalaGenerator(mixins),
+      new ConfigurableScalaGenerator(mixins),
       new GeneratorRunnerOptions(
         targetDirectoryPath,
         sources,

--- a/scala/generator/src/main/scala/org/coursera/courier/generator/GeneratorMixin.scala
+++ b/scala/generator/src/main/scala/org/coursera/courier/generator/GeneratorMixin.scala
@@ -1,0 +1,19 @@
+package org.coursera.courier.generator
+
+import org.coursera.courier.generator.specs.Definition
+
+import scala.collection.immutable
+
+trait GeneratorMixin {
+  def extraClassExpressions(definition: Definition): immutable.Seq[String] =
+    List.empty
+  def extraCompanionExpressions(definition: Definition): immutable.Seq[String] =
+    List.empty
+}
+
+object NilGeneratorMixin extends GeneratorMixin {
+  override def extraClassExpressions(definition: Definition): immutable.Seq[String] =
+    List.empty
+  override def extraCompanionExpressions(definition: Definition): immutable.Seq[String] =
+    List.empty
+}

--- a/scala/generator/src/main/scala/org/coursera/courier/generator/ScalaDataTemplateGenerator.scala
+++ b/scala/generator/src/main/scala/org/coursera/courier/generator/ScalaDataTemplateGenerator.scala
@@ -16,51 +16,5 @@
 
 package org.coursera.courier.generator
 
-import com.linkedin.pegasus.generator.JavaCodeGeneratorBase
-import com.linkedin.pegasus.generator.PegasusDataTemplateGenerator
-import org.coursera.courier.ScalaGenerator
-import org.coursera.courier.api.DefaultGeneratorRunner
-import org.coursera.courier.api.GeneratorRunnerOptions
-
-import scala.collection.JavaConverters._
-
-/**
- * Generates Scala data bindings classes from .pdsc schemas.
- *
- * Both the class and companion object hook into the extension points of rest.li-sbt-plugin.
- */
-object ScalaDataTemplateGenerator {
-  def main(args: Array[String]) {
-    if (args.length != 3) {
-      println(
-        s"Usage: ${ScalaDataTemplateGenerator.getClass.getName} " +
-          s"targetDirectoryPath resolverPath sourcePath1[:sourcePath2]+")
-      System.exit(1)
-    }
-    val targetDirectoryPath = args(0)
-    val resolverPath = args(1)
-    val sources = args(2).split(java.io.File.pathSeparator)
-    val generateImported =
-      Option(System.getProperty(PegasusDataTemplateGenerator.GENERATOR_GENERATE_IMPORTED))
-        .exists(_.toBoolean)
-    val defaultPackage = System.getProperty(JavaCodeGeneratorBase.GENERATOR_DEFAULT_PACKAGE)
-    val generateTyperefs = false
-    val generatePredef = false // set to true temporarily to manually generateRecord predef
-
-    val result = new DefaultGeneratorRunner().run(
-      new ScalaGenerator(),
-      new GeneratorRunnerOptions(
-        targetDirectoryPath,
-        sources,
-        resolverPath)
-        .setDefaultPackage(defaultPackage)
-        .setDataNamespace(CourierPredef.dataNamespace)
-        .setGenerateImported(generateImported)
-        .setGenerateTyperefs(generateTyperefs)
-        .setGeneratePredef(generatePredef))
-
-    result.getTargetFiles.asScala.foreach { file =>
-      System.out.println(file.getAbsolutePath)
-    }
-  }
-}
+object ScalaDataTemplateGenerator
+    extends AbstractScalaDataTemplateGenerator(NilGeneratorMixin)

--- a/scala/generator/src/main/twirl/org/coursera/courier/templates/ArrayClass.scala.txt
+++ b/scala/generator/src/main/twirl/org/coursera/courier/templates/ArrayClass.scala.txt
@@ -1,4 +1,4 @@
-@(array: org.coursera.courier.generator.specs.ArrayDefinition)
+@(array: org.coursera.courier.generator.specs.ArrayDefinition, mixin: org.coursera.courier.generator.GeneratorMixin)
 
 @import com.linkedin.data.schema.SchemaToJsonEncoder
 @import com.linkedin.data.schema.JsonBuilder
@@ -82,6 +82,10 @@
   }
 
   override def clone(): DataTemplate[DataList] = this
+
+  @mixin.extraClassExpressions(array).map { expression =>
+    @expression
+  }
 }
 
 object @(array.scalaType) extends ArrayCompanion[@(array.scalaType)] {
@@ -167,5 +171,9 @@ object @(array.scalaType) extends ArrayCompanion[@(array.scalaType)] {
         @(array.scalaType)(traversable)
       }
     }
+  }
+
+  @mixin.extraCompanionExpressions(array).map { expression =>
+    @expression
   }
 }

--- a/scala/generator/src/main/twirl/org/coursera/courier/templates/ContainedTypes.scala.txt
+++ b/scala/generator/src/main/twirl/org/coursera/courier/templates/ContainedTypes.scala.txt
@@ -1,4 +1,4 @@
-@(definition: org.coursera.courier.generator.specs.Definition)
+@(definition: org.coursera.courier.generator.specs.Definition, mixin: org.coursera.courier.generator.GeneratorMixin)
 
 @import org.coursera.courier.generator.specs._
 
@@ -6,12 +6,12 @@
   @referenced.enclosingDefinition match {
     case Some(container) if container == definition => {
       @referenced match {
-        case enclosedUnion: UnionDefinition => { @UnionClass(enclosedUnion) }
-        case enclosedRecord: RecordDefinition => { @RecordClass(enclosedRecord) }
-        case enclosedMap: MapDefinition => { @MapClass(enclosedMap) }
-        case enclosedArray: ArrayDefinition => { @ArrayClass(enclosedArray) }
-        case enclosedEnum: EnumDefinition => { @EnumClass(enclosedEnum) }
-        case enclosedTyperef: TyperefDefinition => { @TyperefClass(enclosedTyperef) }
+        case enclosedUnion: UnionDefinition => { @UnionClass(enclosedUnion, mixin) }
+        case enclosedRecord: RecordDefinition => { @RecordClass(enclosedRecord, mixin) }
+        case enclosedMap: MapDefinition => { @MapClass(enclosedMap, mixin) }
+        case enclosedArray: ArrayDefinition => { @ArrayClass(enclosedArray, mixin) }
+        case enclosedEnum: EnumDefinition => { @EnumClass(enclosedEnum, mixin) }
+        case enclosedTyperef: TyperefDefinition => { @TyperefClass(enclosedTyperef, mixin) }
       }
     }
     case _ => { }

--- a/scala/generator/src/main/twirl/org/coursera/courier/templates/EnumClass.scala.txt
+++ b/scala/generator/src/main/twirl/org/coursera/courier/templates/EnumClass.scala.txt
@@ -1,4 +1,4 @@
-@(enum: org.coursera.courier.generator.specs.EnumDefinition)
+@(enum: org.coursera.courier.generator.specs.EnumDefinition, mixin: org.coursera.courier.generator.GeneratorMixin)
 
 @import com.linkedin.data.schema.SchemaToJsonEncoder
 @import com.linkedin.data.schema.JsonBuilder
@@ -17,7 +17,12 @@
 }
 
 sealed abstract class @(enum.enumName)(name: String, properties: Option[DataMap])
-  extends ScalaEnumTemplateSymbol(name, properties)
+  extends ScalaEnumTemplateSymbol(name, properties) {
+
+  @mixin.extraClassExpressions(enum).map { expression =>
+    @expression
+  }
+}
 
 @ClassAnnotations(enum) object @enum.enumName extends ScalaEnumTemplate[@(enum.enumName)] {
 
@@ -43,4 +48,8 @@ sealed abstract class @(enum.enumName)(name: String, properties: Option[DataMap]
   }
 
   val SCHEMA = DataTemplateUtil.parseSchema(@("\"\"\"" + SchemaToJsonEncoder.schemaToJson(enum.enumSchema, JsonBuilder.Pretty.COMPACT) + "\"\"\"")).asInstanceOf[EnumDataSchema]
+
+  @mixin.extraCompanionExpressions(enum).map { expression =>
+    @expression
+  }
 }

--- a/scala/generator/src/main/twirl/org/coursera/courier/templates/MapClass.scala.txt
+++ b/scala/generator/src/main/twirl/org/coursera/courier/templates/MapClass.scala.txt
@@ -1,4 +1,4 @@
-@(map: org.coursera.courier.generator.specs.MapDefinition)
+@(map: org.coursera.courier.generator.specs.MapDefinition, mixin: org.coursera.courier.generator.GeneratorMixin)
 
 @import com.linkedin.data.schema.SchemaToJsonEncoder
 @import com.linkedin.data.schema.JsonBuilder
@@ -132,6 +132,10 @@
   override def copy(): DataTemplate[DataMap] = this
 
   override def clone(): DataTemplate[DataMap] = this
+
+  @mixin.extraClassExpressions(map).map { expression =>
+    @expression
+  }
 }
 
 object @(map.scalaType) extends MapCompanion[@(map.scalaType)]{
@@ -147,7 +151,7 @@ object @(map.scalaType) extends MapCompanion[@(map.scalaType)]{
   }
 
   @* Generate any contained types as inner classes. *@
-  @ContainedTypes(map)
+  @ContainedTypes(map, mixin)
 
   val empty = @(map.scalaType)()
 
@@ -210,5 +214,9 @@ object @(map.scalaType) extends MapCompanion[@(map.scalaType)]{
         @(map.scalaType)(map)
       }
     }
+  }
+
+  @mixin.extraCompanionExpressions(map).map { expression =>
+    @expression
   }
 }

--- a/scala/generator/src/main/twirl/org/coursera/courier/templates/RecordClass.scala.txt
+++ b/scala/generator/src/main/twirl/org/coursera/courier/templates/RecordClass.scala.txt
@@ -1,4 +1,4 @@
-@(record: org.coursera.courier.generator.specs.RecordDefinition)
+@(record: org.coursera.courier.generator.specs.RecordDefinition, mixin: org.coursera.courier.generator.GeneratorMixin)
 
 @import com.linkedin.data.schema.SchemaToJsonEncoder
 @import com.linkedin.data.schema.JsonBuilder
@@ -168,6 +168,10 @@
   }
 
   override def clone(): @(record.scalaType) = this
+
+  @mixin.extraClassExpressions(record).map { expression =>
+    @expression
+  }
 }
 
 object @(record.scalaType) extends RecordCompanion[@(record.scalaType)] {
@@ -183,7 +187,7 @@ object @(record.scalaType) extends RecordCompanion[@(record.scalaType)] {
   }
 
   @* Generate any contained types as inner classes. *@
-  @ContainedTypes(record)
+  @ContainedTypes(record, mixin)
 
   private object Fields {
     @record.fields.map { field =>
@@ -224,5 +228,9 @@ object @(record.scalaType) extends RecordCompanion[@(record.scalaType)] {
     case _ => {
       /* unapply() not available for records with more than 22 fields due to Scala's Tuple limit. */
     }
+  }
+
+  @mixin.extraCompanionExpressions(record).map { expression =>
+    @expression
   }
 }

--- a/scala/generator/src/main/twirl/org/coursera/courier/templates/TyperefClass.scala.txt
+++ b/scala/generator/src/main/twirl/org/coursera/courier/templates/TyperefClass.scala.txt
@@ -1,4 +1,4 @@
-@(typeref: org.coursera.courier.generator.specs.TyperefDefinition)
+@(typeref: org.coursera.courier.generator.specs.TyperefDefinition, mixin: org.coursera.courier.generator.GeneratorMixin)
 
 @import com.linkedin.data.schema.SchemaToJsonEncoder
 @import com.linkedin.data.schema.JsonBuilder
@@ -18,8 +18,14 @@
 
 @ClassAnnotations(typeref) final class @(typeref.scalaType)() extends TyperefInfo(@(typeref.scalaType).SCHEMA) {
   @(typeref.scalaType) // force static initialization
+  @mixin.extraClassExpressions(typeref).map { expression =>
+    @expression
+  }
 }
 
 object @(typeref.scalaType) {
   val SCHEMA = DataTemplateUtil.parseSchema(@("\"\"\"" + SchemaToJsonEncoder.schemaToJson(typeref.typerefSchema, JsonBuilder.Pretty.COMPACT) + "\"\"\"")).asInstanceOf[TyperefDataSchema]
+  @mixin.extraCompanionExpressions(typeref).map { expression =>
+    @expression
+  }
 }

--- a/scala/generator/src/main/twirl/org/coursera/courier/templates/UnionClass.scala.txt
+++ b/scala/generator/src/main/twirl/org/coursera/courier/templates/UnionClass.scala.txt
@@ -1,4 +1,4 @@
-@(union: org.coursera.courier.generator.specs.UnionDefinition)
+@(union: org.coursera.courier.generator.specs.UnionDefinition, mixin: org.coursera.courier.generator.GeneratorMixin)
 
 @import com.linkedin.data.schema.SchemaToJsonEncoder
 @import com.linkedin.data.schema.JsonBuilder
@@ -47,6 +47,10 @@
   override def toString: String = ScalaRunTime._toString(this)
 
   override def hashCode: Int = ScalaRunTime._hashCode(this)
+
+  @mixin.extraClassExpressions(union).map { expression =>
+    @expression
+  }
 }
 
 object @(union.scalaType) extends UnionCompanion[@(union.scalaType)] @(if(union.containingTyperef.isDefined){"with UnionWithTyperefCompanion[" + union.scalaType + "] "}){
@@ -178,5 +182,9 @@ object @(union.scalaType) extends UnionCompanion[@(union.scalaType)] @(if(union.
         None
       }
     }
+  }
+
+  @mixin.extraCompanionExpressions(union).map { expression =>
+    @expression
   }
 }

--- a/scala/test-lib/build.sbt
+++ b/scala/test-lib/build.sbt
@@ -17,9 +17,9 @@ javaOptions in Test +=
 // Test generator
 forkedVmCourierGeneratorSettings
 
-forkedVmCourierMainClass := "org.coursera.courier.generator.ScalaDataTemplateGenerator"
+forkedVmCourierMainClass := "org.coursera.courier.generator.TestScalaDataTemplateGenerator"
 
-forkedVmCourierClasspath := (dependencyClasspath in Runtime in scalaGenerator).value.files
+forkedVmCourierClasspath := (dependencyClasspath in Runtime in scalaGeneratorTestGenerator).value.files
 
 forkedVmSourceDirectory := (sourceDirectory in referenceSuite).value / "main" / "courier"
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.1.4"
+version in ThisBuild := "2.1.5"


### PR DESCRIPTION
Wouldn't it be nice if our Coursera's courier records automatically included Coursera JSON format implicits? Now, they can! Scala generators now take a `GeneratorMixin` class that can append additional lines at the end of each generated class and companion object. Mixin methods are called with `org.coursera.courier.generator.specs.Definition`, so mixin behavior can be schema-aware.

This PR includes core changes and tests. I struggled somewhat trying to declare a custom generator (with mixins) for my tests. Ultimately it worked to add a new library solely for the test generator, but I'd be happy to learn of a better way to do this. 