### PR TITLE
Fix directReferencedTypes in TyperefDefinition

### DIFF
--- a/gradle-plugin/gradle.properties
+++ b/gradle-plugin/gradle.properties
@@ -1,2 +1,2 @@
-courierVersion=2.1.5
+courierVersion=2.1.6
 scalaMajorVersion=2.11

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -35,7 +35,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <scalaMajorVersion>2.11</scalaMajorVersion>
     <scalaVersion>2.11.5</scalaVersion>
-    <courierVersion>2.1.5</courierVersion>
+    <courierVersion>2.1.6</courierVersion>
     <javaVersion>1.7</javaVersion>
   </properties>
   <url>http://github.com/coursera/courier</url>

--- a/scala/generator/src/main/scala/org/coursera/courier/generator/specs/TyperefDefinition.scala
+++ b/scala/generator/src/main/scala/org/coursera/courier/generator/specs/TyperefDefinition.scala
@@ -39,7 +39,7 @@ case class TyperefDefinition(override val spec: TyperefTemplateSpec) extends Def
     Option(typerefSchema.getDoc).flatMap(ScaladocEscaping.stringToScaladoc)
   }
 
-  def directReferencedTypes: Set[Definition] = Set.empty
+  def directReferencedTypes: Set[Definition] = Set(dereferencedType)
 }
 
 object TyperefDefinition {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.1.5"
+version in ThisBuild := "2.1.6"


### PR DESCRIPTION
Will now return the proper dereferenced type for directReferencedTypes instead of empty. 
Choosing to use typerefSchema.getDereferencedDataSchema because any function that would want to do operations on a typeref likely only cares about the final dereferenced type given the fact that a typeref can only reference one DataSchema. If you had a chain of typerefs, you would have to do additional iterations to find the dereferenced type if using typerefSchema.getRef.