### PR TITLE
[idea plugin] Go to Courier definition action failing with NoClassDefFoundError

### DIFF
--- a/idea-plugin/META-INF/plugin.xml
+++ b/idea-plugin/META-INF/plugin.xml
@@ -17,6 +17,7 @@
   <idea-version since-build="131"/>
 
   <depends>com.intellij.modules.lang</depends>
+  <depends>com.intellij.modules.java</depends>
 
   <extensions defaultExtensionNs="com.intellij">
     <!-- Add your extensions here -->


### PR DESCRIPTION
Since IntelliJ IDEA 2019.2 release, the Java functionality was extracted as a separate plugin. Therefore it needs to be declared as a dependency.

More info: https://blog.jetbrains.com/platform/2019/06/java-functionality-extracted-as-a-plugin/